### PR TITLE
Simplifying `DecodingGraph`

### DIFF
--- a/qiskit_qec/decoders/graph_decoder.py
+++ b/qiskit_qec/decoders/graph_decoder.py
@@ -398,7 +398,7 @@ class GraphDecoder:
         Args:
             results (dict): A results dictionary from running a circuit
             of the code.
-            logical: Encoded logical value at readout.
+            logical (str): Encoded logical value at readout.
             algorithm (str): Choice of which decoder to use.
 
         Returns:

--- a/tests/repetition_codes/test_codes.py
+++ b/tests/repetition_codes/test_codes.py
@@ -20,8 +20,6 @@ import unittest
 
 import sys
 
-import retworkx as rx
-
 from qiskit import execute, Aer, QuantumCircuit
 from qiskit.providers.aer.noise import NoiseModel
 from qiskit.providers.aer.noise.errors import depolarizing_error


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

-  [x] I have added the tests to cover my changes.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the CONTRIBUTING document.
-->

### Summary

Functionality has been moved between the `RepetitionCodeCircuit`,`DecodingGraph` and `GraphDecoder` objects.
* `RepetitionCodeCircuit` now includes the method to describe output strings as a set of nodes.
*  `DecodingGraph` uses the above functionality to produce the syndrome graph, without needing to know most details of the circuit.
* `GraphDecoder` now calculates logical probabilities from the raw results obtained from running a circuit, rather than requiring `RepetitionCodeCircuit` to produce processed results.
* `RepetitionCodeCircuit` no longer produces a counts dictionary of processed results.

So, basically:
* `DecodingGraph` just focusses on being a syndrome graph, with methods that analyze properties of the graph or create required subgraphs.
* `RepetitionCodeCircuit` does everything that requires explicit knowledge of the circuit and code.
* `GraphDecoder` (which will be deprecated soon, in favour of the PR #155 decoder) just does the decoding.