### PR TITLE
fix presentation of automorphism group generators

### DIFF
--- a/gap/aut.g
+++ b/gap/aut.g
@@ -177,9 +177,9 @@ end;
 # of coordinate permutations and a corresponding list of
 # local relabelings of the non-zero elements of GF(4).
 # These can be interpreted as pairs of coordinate permutations
-# and single-qubit Clifford gates that map the stabilizer
-# code space to itself. In the returned record, the Clifford
-# gates are encoded as:
+# preceeded by single-qubit Clifford gates that, taken together,
+# map the stabilizer code space to itself. In the returned
+# record, the Clifford gates are encoded as:
 # 'i': identity
 # 'r': 1 -> \omega -> \omega^2 (x -> z -> y)
 # 'R': 1 -> \omega^2 -> \omega (x -> y -> z)
@@ -187,7 +187,7 @@ end;
 # 'S': 1 <-> \omega^2 (x <-> y)
 # 'H': 1 <-> \omega (x <-> z)
 reformat := function(A, n)
-  local autgens, g, img, perm, sing, tup, permlist, lclist, i;
+  local autgens, g, img, perm, sing, sing2, tup, permlist, lclist, i;
   autgens := GeneratorsOfGroup(A);
   permlist := [];
   lclist := [];
@@ -214,8 +214,13 @@ reformat := function(A, n)
         Append(sing, "S");  # exchange 1 and a^2, fix a
       fi;
     od;
+    # Apply perm^-1 to sing
+    sing2 := [];
+    for i in [1..n] do
+      Append(sing2, [sing[perm[i]]]);
+    od;
     Add(permlist, perm);
-    Add(lclist, sing);
+    Add(lclist, sing2);
   od;
   return rec(permutations:=permlist, locals:=lclist);
 end;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Present the generators as pairs of coordinate permutations *preceded* by single-qubit Clifford gates that, taken together,
map the gauge group to itself.

### Details and comments

This is a small change of a few lines to reformat the output.