### PR TITLE
Issue 258 basexppauli class skeleton

### DIFF
--- a/qiskit_qec/operators/__init__.py
+++ b/qiskit_qec/operators/__init__.py
@@ -27,8 +27,10 @@ Operators module classes and functions
     PauliList
     Pauli
     BasePauli
+    BaseXPPauli
 """
 
 from .base_pauli import BasePauli
 from .pauli import Pauli
 from .pauli_list import PauliList
+from .base_xp_pauli import BaseXPPauli

--- a/qiskit_qec/operators/base_pauli.py
+++ b/qiskit_qec/operators/base_pauli.py
@@ -773,7 +773,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         squeeze: bool = True,
         index_str: str = "",
     ) -> Union[str, List[str]]:
-        """Returns the string representatiojn for a Pauli or Paulis.
+        """Returns the string representation for a Pauli or Paulis.
 
         Args:
             output_pauli_encoding (optional): Encoding used to represent phases.

--- a/qiskit_qec/operators/base_pauli.py
+++ b/qiskit_qec/operators/base_pauli.py
@@ -74,7 +74,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         Args:
             matrix: Input GF(2) symplectic matrix
-            phase_exp (optional): Phase exponent vector for imput matrix. A value of None will
+            phase_exp (optional): Phase exponent vector for input matrix. A value of None will
                 result in an a complex coefficients of 1 for each Pauli operator. Defaults to None.
             order: Set to 'xz' or 'zx'. Defines which side the x and z parts of the input matrix
 

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -13,7 +13,6 @@
 # Part of the QEC framework
 """Module for base XP pauli"""
 
-import copy
 import numbers
 from typing import List, Optional, Union
 
@@ -28,8 +27,6 @@ from qiskit.circuit.delay import Delay
 from qiskit.circuit.instruction import Instruction
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info.operators.mixins import AdjointMixin, MultiplyMixin
-from qiskit_qec.linear import matrix as mt
-from qiskit_qec.linear.symplectic import symplectic_product
 from qiskit_qec.utils import xp_pauli_rep
 
 
@@ -117,90 +114,111 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
     @property
     def x(self):
+        """_summary_"""
         pass
 
     @x.setter
     def x(self, val: np.ndarray):
+        """_summary_"""
         pass
 
     # @final Add when python >= 3.8
     @property
     def _x(self):  # pylint: disable=invalid-name
+        """_summary_"""
         pass
 
     # @final Add when python >= 3.8
     @_x.setter
     def _x(self, val):  # pylint: disable=invalid-name
+        """_summary_"""
         pass
 
     @property
     def z(self):
+        """_summary_"""
         pass
 
     @z.setter
     def z(self, val):
+        """_summary_"""
         pass
 
     # @final Add when python >= 3.8
     @property
     def _z(self):  # pylint: disable=invalid-name
+        """_summary_"""
         pass
 
     # @final Add when python >= 3.8
     @_z.setter
     def _z(self, val):  # pylint: disable=invalid-name
+        """_summary_"""
         pass
 
     @property
     def num_y(self):
+        """_summary_"""
         pass
 
     @property
     def tensor_encoding(self):
+        """_summary_"""
         pass
 
     @classmethod
     def set_tensor_encoding(cls, encoding: str = xp_pauli_rep.DEFAULT_EXTERNAL_TENSOR_ENCODING):
+        """_summary_"""
         pass
 
     @property
     def phase_encoding(self):
+        """_summary_"""
         pass
 
     @classmethod
     def set_phase_encoding(cls, encoding: str = xp_pauli_rep.DEFAULT_EXTERNAL_PHASE_ENCODING):
+        """_summary_"""
         pass
 
     @property
     def pauli_encoding(self):
+        """_summary_"""
         pass
 
     @classmethod
     def set_pauli_encoding(cls, encoding: str = xp_pauli_rep.DEFAULT_EXTERNAL_XP_PAULI_ENCODING):
+        """_summary_"""
         pass
 
     @property
     def syntax(self):
+        """_summary_"""
         pass
 
     @classmethod
     def set_syntax(cls, syntax_code: Optional[int] = None, syntax_str: Optional[str] = "Product"):
+        """_summary_"""
         pass
 
     @property
     def print_phase_encoding(self):
+        """_summary_"""
         pass
 
     @classmethod
     def set_print_phase_encoding(cls, phase_encoding: Optional[str] = None):
+        """_summary_"""
         pass
 
     @property
     def qubit_order(self):
+        """_summary_"""
         pass
 
     @classmethod
     def set_qubit_order(cls, qubit_order: Optional[str] = None):
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -208,14 +226,17 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def __imul__(self, other: "BaseXPPauli") -> "BaseXPPauli":
+        """_summary_"""
         pass
 
     def __neg__(self) -> "BaseXPPauli":
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
 
     def copy(self) -> "BaseXPPauli":
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -231,6 +252,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         front: bool = False,
         inplace: bool = False,
     ) -> "BaseXPPauli":
+        """_summary_"""
         pass
 
     @staticmethod
@@ -241,20 +263,24 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         front: bool = False,
         inplace: bool = False,
     ) -> "BaseXPPauli":
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
 
     def tensor(self, other):
+        """_summary_"""
         pass
 
     @staticmethod
     def _tensor(a: "BaseXPPauli", b: "BaseXPPauli"):
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
 
     def expand(self, other):
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -262,20 +288,25 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def _multiply(self, phase, roundit=True) -> "BaseXPPauli":  # pylint: disable=arguments-renamed
+        """_summary_"""
         pass
 
     # Needed by AdjointMixin class
 
     def conjugate(self, inplace=False) -> "BaseXPPauli":
+        """_summary_"""
         pass
 
     def transpose(self, inplace: bool = False) -> "BaseXPPauli":
+        """_summary_"""
         pass
 
     def commutes(self, other: "BaseXPPauli", qargs: List = None) -> np.ndarray:
+        """_summary_"""
         pass
 
     def _commutes(self, other: "BaseXPPauli", qargs: List = None) -> np.ndarray:
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -283,6 +314,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def all_commutes(self, other: "BaseXPPauli") -> np.ndarray:
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -290,6 +322,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def evolve(self, other: "BaseXPPauli", qargs: Union[None, List, int] = None, frame: str = "h"):
+        """_summary_"""
         pass
 
     def _evolve_clifford(
@@ -298,6 +331,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         qargs: Union[None, List, int] = None,
         frame: str = "h",
     ):
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -305,6 +339,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def _eq(self, other):
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -322,6 +357,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         squeeze: bool = True,
         index_str: str = "",
     ) -> Union[str, List[str]]:
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -330,14 +366,17 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def _count_y(self) -> np.ndarray:
+        """_summary_"""
         pass
 
     @staticmethod
     def _stack(array: np.ndarray, size: int, vertical: bool = True) -> np.ndarray:
+        """_summary_"""
         pass
 
     @staticmethod
     def _phase_from_complex(coeff: numbers.Complex) -> np.ndarray:
+        """_summary_"""
         pass
 
     # ---------------------------------------------------------------------
@@ -349,49 +388,73 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         circuit: Union[Barrier, Delay, QuantumCircuit, Instruction],
         qargs: Optional[List] = None,
     ) -> "BaseXPPauli":
+        """_summary_"""
         pass
+
 
 # ---------------------------------------------------------------------
 # Evolution by Clifford gates
 # ---------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def _evolve_h(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _evolve_s(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _evolve_sdg(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
+
 
 # pylint: disable=unused-argument
 def _evolve_i(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
 
 
 def _evolve_x(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
+
 
 def _evolve_y(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
+
 
 def _evolve_z(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
 
+
 def _evolve_cx(base_xp_pauli: "BaseXPPauli", qctrl: int, qtrgt: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
+
 
 def _evolve_cz(  # pylint: disable=invalid-name
     base_xp_pauli: "BaseXPPauli", q1: int, q2: int  # pylint: disable=invalid-name
 ) -> "BaseXPPauli":
+    """_summary_"""
     pass
 
+
 def _evolve_cy(base_xp_pauli: "BaseXPPauli", qctrl: int, qtrgt: int) -> "BaseXPPauli":
+    """_summary_"""
     pass
+
 
 def _evolve_swap(  # pylint: disable=invalid-name
     base_xp_pauli: "BaseXPPauli", q1: int, q2: int  # pylint: disable=invalid-name
 ) -> "BaseXPPauli":
+    """_summary_"""
     pass

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -53,7 +53,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         self,
         matrix: Union[np.ndarray, None] = None,
         phase_exp: Union[None, np.ndarray, np.integer] = None,
-        N: int = None,
+        precision: int = None,
         order: str = "xz",
     ) -> None:
         # TODO: Need to update this docstring once the representation to be
@@ -78,7 +78,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             matrix: Input GF(2) symplectic matrix
             phase_exp (optional): Phase exponent vector for input matrix. A value of None will
                 result in an a complex coefficients of 1 for each XP operator. Defaults to None.
-            N: Precision of XP operators. Must be an integer greater than or equal to 2.
+            precision: Precision of XP operators. Must be an integer greater than or equal to 2.
             order: Set to 'xz' or 'zx'. Defines which side the x and z parts of the input matrix
 
         Raises: QiskitError: matrix and phase_exp sizes are not compatible

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -32,8 +32,8 @@ from qiskit_qec.utils import xp_pauli_rep
 
 # pylint: disable=no-member
 class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
-    r"""Symplectic representation of a list of N-qubit XP operators with phases using
-    numpy arrays for symplectic matrices and phase vectors.
+    r"""Symplectic representation of a list of N-qubit XP operators with phases
+    using numpy arrays for generalized symplectic matrices and phase vectors.
 
     Base class for XPPauli and XPPauliList.
     """
@@ -48,31 +48,37 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
     PRINT_PHASE_ENCODING = None
 
+    # pylint: disable=unused-argument
     def __init__(
         self,
         matrix: Union[np.ndarray, None] = None,
         phase_exp: Union[None, np.ndarray, np.integer] = None,
+        N: int = None,
         order: str = "xz",
     ) -> None:
-        """A BaseXPPauli object represents a list N-qubit Pauli operators with phases.
-        Numpy arrays are used to represent the symplectic matrix represention of these
-        Paulis. The phases of the Paulis are stored encoded. The phases of the Pauli
+        # TODO: Need to update this docstring once the representation to be
+        # used for XP operators has been decided. In addition,
+        # (-i)^phase_exp Z^z X^x and GF(2) need to be updated to XP operators.
+        """A BaseXPPauli object represents a list N-qubit XP Pauli operators with phases.
+        Numpy arrays are used to represent the generalized symplectic matrix represention of these
+        XP operators. The phases of the XP operators are stored encoded. The phases of the XP operators
         operators are internally encoded in the '-iZX' Pauli encoding (See the xp_pauli_rep
-        module for more details). That is a Pauli operator is represented as symplectic
+        module for more details). That is a XP operator is represented as generalized symplectic
         vector V and a phase exponent phase_exp such that:
 
         (-i)^phase_exp Z^z X^x
 
-        where V = [x, z] and phase_exp is a vector of Z_4 elements (0,1,2,3). A list
-        of Pauli operators is represented as a symplectic matrix S and a phase exponent
-        vector phase_exp such that the rows or S are the symplectic vector representations
-        of the Paulis and the phase_exp vector store the phase exponent of each
-        associated Pauli Operator.
+        where V = [x, z] and phase_exp is a vector of Z_2N elements (0,1,2,...,2N-1). A list
+        of XP operators is represented as a generalized symplectic matrix S and a phase exponent
+        vector phase_exp such that the rows or S are the generalized symplectic vector representations
+        of the XP operators and the phase_exp vector store the phase exponent of each
+        associated XP Operator.
 
         Args:
             matrix: Input GF(2) symplectic matrix
-            phase_exp (optional): Phase exponent vector for imput matrix. A value of None will
-                result in an a complex coefficients of 1 for each Pauli operator. Defaults to None.
+            phase_exp (optional): Phase exponent vector for input matrix. A value of None will
+                result in an a complex coefficients of 1 for each XP operator. Defaults to None.
+            N: Precision of XP operators. Must be an integer greater than or equal to 2.
             order: Set to 'xz' or 'zx'. Defines which side the x and z parts of the input matrix
 
         Raises: QiskitError: matrix and phase_exp sizes are not compatible

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -92,8 +92,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         """
 
         if matrix is None or matrix.size == 0:
-            matrix = np.empty(shape=(0, 0), dtype=np.int8)
-            phase_exp = np.empty(shape=(0,), dtype=np.int8)
+            matrix = np.empty(shape=(0, 0), dtype=np.int64)
+            phase_exp = np.empty(shape=(0,), dtype=np.int64)
         matrix = np.atleast_2d(matrix)
         num_qubits = matrix.shape[1] >> 1
 
@@ -106,7 +106,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         self.matrix = matrix
         self._num_paulis = self.matrix.shape[0]
         if phase_exp is None:
-            self._phase_exp = np.zeros(shape=(self.matrix.shape[0],), dtype=np.int8)
+            self._phase_exp = np.zeros(shape=(self.matrix.shape[0],), dtype=np.int64)
         else:
             self._phase_exp = np.atleast_1d(phase_exp)
         if self._phase_exp.shape[0] != self.matrix.shape[0]:

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -1,0 +1,397 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# Part of the QEC framework
+"""Module for base XP pauli"""
+
+import copy
+import numbers
+from typing import List, Optional, Union
+
+import numpy as np
+
+# Must be imported as follows to avoid circular import errors
+import qiskit.quantum_info.operators.symplectic.clifford
+from qiskit import QiskitError
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.barrier import Barrier
+from qiskit.circuit.delay import Delay
+from qiskit.circuit.instruction import Instruction
+from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.quantum_info.operators.mixins import AdjointMixin, MultiplyMixin
+from qiskit_qec.linear import matrix as mt
+from qiskit_qec.linear.symplectic import symplectic_product
+from qiskit_qec.utils import xp_pauli_rep
+
+
+# pylint: disable=no-member
+class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
+    r"""Symplectic representation of a list of N-qubit XP operators with phases using
+    numpy arrays for symplectic matrices and phase vectors.
+
+    Base class for XPPauli and XPPauliList.
+    """
+
+    # External string formats used when displaying Pauli's as strings
+    EXTERNAL_TENSOR_ENCODING = xp_pauli_rep.DEFAULT_EXTERNAL_TENSOR_ENCODING
+    EXTERNAL_PHASE_ENCODING = xp_pauli_rep.DEFAULT_EXTERNAL_PHASE_ENCODING
+    EXTERNAL_XP_PAULI_ENCODING = EXTERNAL_PHASE_ENCODING + EXTERNAL_TENSOR_ENCODING
+
+    EXTERNAL_SYNTAX = xp_pauli_rep.PRODUCT_SYNTAX
+    EXTERNAL_QUBIT_ORDER = xp_pauli_rep.DEFAULT_QUBIT_ORDER
+
+    PRINT_PHASE_ENCODING = None
+
+    def __init__(
+        self,
+        matrix: Union[np.ndarray, None] = None,
+        phase_exp: Union[None, np.ndarray, np.integer] = None,
+        order: str = "xz",
+    ) -> None:
+        """A BaseXPPauli object represents a list N-qubit Pauli operators with phases.
+        Numpy arrays are used to represent the symplectic matrix represention of these
+        Paulis. The phases of the Paulis are stored encoded. The phases of the Pauli
+        operators are internally encoded in the '-iZX' Pauli encoding (See the xp_pauli_rep
+        module for more details). That is a Pauli operator is represented as symplectic
+        vector V and a phase exponent phase_exp such that:
+
+        (-i)^phase_exp Z^z X^x
+
+        where V = [x, z] and phase_exp is a vector of Z_4 elements (0,1,2,3). A list
+        of Pauli operators is represented as a symplectic matrix S and a phase exponent
+        vector phase_exp such that the rows or S are the symplectic vector representations
+        of the Paulis and the phase_exp vector store the phase exponent of each
+        associated Pauli Operator.
+
+        Args:
+            matrix: Input GF(2) symplectic matrix
+            phase_exp (optional): Phase exponent vector for imput matrix. A value of None will
+                result in an a complex coefficients of 1 for each Pauli operator. Defaults to None.
+            order: Set to 'xz' or 'zx'. Defines which side the x and z parts of the input matrix
+
+        Raises: QiskitError: matrix and phase_exp sizes are not compatible
+
+        Examples:
+            >>> matrix = numpy.array([[1,1,0,0],[0,1,0,1]])
+            >>> base_xp_pauli = BaseXPPauli(matrix)
+
+        See Also:
+            Pauli, PauliList
+        """
+
+        if matrix is None or matrix.size == 0:
+            matrix = np.empty(shape=(0, 0), dtype=np.int8)
+            phase_exp = np.empty(shape=(0,), dtype=np.int8)
+        matrix = np.atleast_2d(matrix)
+        num_qubits = matrix.shape[1] >> 1
+
+        if order == "zx":
+            nmatrix = np.empty(shape=matrix.shape, dtype=matrix.dtype)
+            nmatrix[:, :num_qubits] = matrix[:, num_qubits:]
+            nmatrix[:, num_qubits:] = matrix[:, :num_qubits]
+            matrix = nmatrix
+
+        self.matrix = matrix
+        self._num_paulis = self.matrix.shape[0]
+        if phase_exp is None:
+            self._phase_exp = np.zeros(shape=(self.matrix.shape[0],), dtype=np.int8)
+        else:
+            self._phase_exp = np.atleast_1d(phase_exp)
+        if self._phase_exp.shape[0] != self.matrix.shape[0]:
+            raise QiskitError("matrix and phase_exp sizes are not compatible")
+
+        super().__init__(num_qubits=num_qubits)
+
+    # ---------------------------------------------------------------------
+    # Properties
+    # ---------------------------------------------------------------------
+
+    @property
+    def x(self):
+        pass
+
+    @x.setter
+    def x(self, val: np.ndarray):
+        pass
+
+    # @final Add when python >= 3.8
+    @property
+    def _x(self):  # pylint: disable=invalid-name
+        pass
+
+    # @final Add when python >= 3.8
+    @_x.setter
+    def _x(self, val):  # pylint: disable=invalid-name
+        pass
+
+    @property
+    def z(self):
+        pass
+
+    @z.setter
+    def z(self, val):
+        pass
+
+    # @final Add when python >= 3.8
+    @property
+    def _z(self):  # pylint: disable=invalid-name
+        pass
+
+    # @final Add when python >= 3.8
+    @_z.setter
+    def _z(self, val):  # pylint: disable=invalid-name
+        pass
+
+    @property
+    def num_y(self):
+        pass
+
+    @property
+    def tensor_encoding(self):
+        pass
+
+    @classmethod
+    def set_tensor_encoding(cls, encoding: str = xp_pauli_rep.DEFAULT_EXTERNAL_TENSOR_ENCODING):
+        pass
+
+    @property
+    def phase_encoding(self):
+        pass
+
+    @classmethod
+    def set_phase_encoding(cls, encoding: str = xp_pauli_rep.DEFAULT_EXTERNAL_PHASE_ENCODING):
+        pass
+
+    @property
+    def pauli_encoding(self):
+        pass
+
+    @classmethod
+    def set_pauli_encoding(cls, encoding: str = xp_pauli_rep.DEFAULT_EXTERNAL_XP_PAULI_ENCODING):
+        pass
+
+    @property
+    def syntax(self):
+        pass
+
+    @classmethod
+    def set_syntax(cls, syntax_code: Optional[int] = None, syntax_str: Optional[str] = "Product"):
+        pass
+
+    @property
+    def print_phase_encoding(self):
+        pass
+
+    @classmethod
+    def set_print_phase_encoding(cls, phase_encoding: Optional[str] = None):
+        pass
+
+    @property
+    def qubit_order(self):
+        pass
+
+    @classmethod
+    def set_qubit_order(cls, qubit_order: Optional[str] = None):
+        pass
+
+    # ---------------------------------------------------------------------
+    # Magic Methods
+    # ---------------------------------------------------------------------
+
+    def __imul__(self, other: "BaseXPPauli") -> "BaseXPPauli":
+        pass
+
+    def __neg__(self) -> "BaseXPPauli":
+        pass
+
+    # ---------------------------------------------------------------------
+
+    def copy(self) -> "BaseXPPauli":
+        pass
+
+    # ---------------------------------------------------------------------
+    # BaseOperator methods
+    # ---------------------------------------------------------------------
+    # Needed by GroupMixin class from BaseOperator class
+
+    # pylint: disable=arguments-differ
+    def compose(
+        self,
+        other: "BaseXPPauli",
+        qargs: Optional[list] = None,
+        front: bool = False,
+        inplace: bool = False,
+    ) -> "BaseXPPauli":
+        pass
+
+    @staticmethod
+    def _compose(
+        a: "BaseXPPauli",
+        b: "BaseXPPauli",
+        qargs: Optional[list] = None,
+        front: bool = False,
+        inplace: bool = False,
+    ) -> "BaseXPPauli":
+        pass
+
+    # ---------------------------------------------------------------------
+
+    def tensor(self, other):
+        pass
+
+    @staticmethod
+    def _tensor(a: "BaseXPPauli", b: "BaseXPPauli"):
+        pass
+
+    # ---------------------------------------------------------------------
+
+    def expand(self, other):
+        pass
+
+    # ---------------------------------------------------------------------
+    # Needed by MultiplyMixin class
+    # ---------------------------------------------------------------------
+
+    def _multiply(self, phase, roundit=True) -> "BaseXPPauli":  # pylint: disable=arguments-renamed
+        pass
+
+    # Needed by AdjointMixin class
+
+    def conjugate(self, inplace=False) -> "BaseXPPauli":
+        pass
+
+    def transpose(self, inplace: bool = False) -> "BaseXPPauli":
+        pass
+
+    def commutes(self, other: "BaseXPPauli", qargs: List = None) -> np.ndarray:
+        pass
+
+    def _commutes(self, other: "BaseXPPauli", qargs: List = None) -> np.ndarray:
+        pass
+
+    # ---------------------------------------------------------------------
+    # Extra all_commutes method
+    # ---------------------------------------------------------------------
+
+    def all_commutes(self, other: "BaseXPPauli") -> np.ndarray:
+        pass
+
+    # ---------------------------------------------------------------------
+    # Evolve Methods
+    # ---------------------------------------------------------------------
+
+    def evolve(self, other: "BaseXPPauli", qargs: Union[None, List, int] = None, frame: str = "h"):
+        pass
+
+    def _evolve_clifford(
+        self,
+        other: qiskit.quantum_info.operators.symplectic.clifford.Clifford,
+        qargs: Union[None, List, int] = None,
+        frame: str = "h",
+    ):
+        pass
+
+    # ---------------------------------------------------------------------
+    # Helper Metods
+    # ---------------------------------------------------------------------
+
+    def _eq(self, other):
+        pass
+
+    # ---------------------------------------------------------------------
+    # Class methods for creating labels -> Uses xp_pauli_rep suite of methods
+    # ---------------------------------------------------------------------
+
+    def to_label(
+        self,
+        output_pauli_encoding: Optional[str] = None,
+        no_phase: bool = False,
+        return_phase: bool = False,
+        syntax: Optional[int] = None,
+        qubit_order: Optional[str] = None,
+        index_start: int = 0,
+        squeeze: bool = True,
+        index_str: str = "",
+    ) -> Union[str, List[str]]:
+        pass
+
+    # ---------------------------------------------------------------------
+    # The methods below should be deprecated eventually as they simply refer
+    # to the newer versions that are now elsewhere.
+    # ---------------------------------------------------------------------
+
+    def _count_y(self) -> np.ndarray:
+        pass
+
+    @staticmethod
+    def _stack(array: np.ndarray, size: int, vertical: bool = True) -> np.ndarray:
+        pass
+
+    @staticmethod
+    def _phase_from_complex(coeff: numbers.Complex) -> np.ndarray:
+        pass
+
+    # ---------------------------------------------------------------------
+    # Apply Clifford to BaseXPPauli
+    # ---------------------------------------------------------------------
+
+    def _append_circuit(
+        self,
+        circuit: Union[Barrier, Delay, QuantumCircuit, Instruction],
+        qargs: Optional[List] = None,
+    ) -> "BaseXPPauli":
+        pass
+
+# ---------------------------------------------------------------------
+# Evolution by Clifford gates
+# ---------------------------------------------------------------------
+
+
+def _evolve_h(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    pass
+
+
+def _evolve_s(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    pass
+
+def _evolve_sdg(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    pass
+
+# pylint: disable=unused-argument
+def _evolve_i(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    pass
+
+
+def _evolve_x(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    pass
+
+def _evolve_y(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    pass
+
+def _evolve_z(base_xp_pauli: "BaseXPPauli", qubit: int) -> "BaseXPPauli":
+    pass
+
+def _evolve_cx(base_xp_pauli: "BaseXPPauli", qctrl: int, qtrgt: int) -> "BaseXPPauli":
+    pass
+
+def _evolve_cz(  # pylint: disable=invalid-name
+    base_xp_pauli: "BaseXPPauli", q1: int, q2: int  # pylint: disable=invalid-name
+) -> "BaseXPPauli":
+    pass
+
+def _evolve_cy(base_xp_pauli: "BaseXPPauli", qctrl: int, qtrgt: int) -> "BaseXPPauli":
+    pass
+
+def _evolve_swap(  # pylint: disable=invalid-name
+    base_xp_pauli: "BaseXPPauli", q1: int, q2: int  # pylint: disable=invalid-name
+) -> "BaseXPPauli":
+    pass

--- a/qiskit_qec/utils/__init__.py
+++ b/qiskit_qec/utils/__init__.py
@@ -28,6 +28,7 @@ Utils module classes and functions
 
     indexer
     pauli_rep
+    xp_pauli_rep
 """
 
-from . import indexer, pauli_rep
+from . import indexer, pauli_rep, xp_pauli_rep

--- a/qiskit_qec/utils/xp_pauli_rep.py
+++ b/qiskit_qec/utils/xp_pauli_rep.py
@@ -30,7 +30,7 @@ from scipy.sparse import csr_matrix
 # Module Variables/States
 # -------------------------------------------------------------------------------
 
-# Set the interal encodings
+# Set the internal encodings
 # The internal encoding cannot be changed by changing this constant
 # These constants are for reference only and do not change the behavior of
 # the XPPauli methods. See [ref] for details on the different encodings

--- a/qiskit_qec/utils/xp_pauli_rep.py
+++ b/qiskit_qec/utils/xp_pauli_rep.py
@@ -22,12 +22,8 @@ from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 from qiskit.circuit import Gate
-from qiskit.circuit.library.generalized_gates import PauliGate
-from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
-from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.scalar_op import ScalarOp
 from scipy.sparse import csr_matrix
-from qiskit_qec.linear.symplectic import count_num_y, is_symplectic_matrix_form
 
 
 # -------------------------------------------------------------------------------
@@ -46,7 +42,9 @@ INTERNAL_XP_PAULI_ENCODING = INTERNAL_PHASE_ENCODING + INTERNAL_TENSOR_ENCODING
 
 DEFAULT_EXTERNAL_TENSOR_ENCODING = "YZX"
 DEFAULT_EXTERNAL_PHASE_ENCODING = "-i"
-DEFAULT_EXTERNAL_XP_PAULI_ENCODING = DEFAULT_EXTERNAL_PHASE_ENCODING + DEFAULT_EXTERNAL_TENSOR_ENCODING
+DEFAULT_EXTERNAL_XP_PAULI_ENCODING = (
+    DEFAULT_EXTERNAL_PHASE_ENCODING + DEFAULT_EXTERNAL_TENSOR_ENCODING
+)
 
 # Set the external encodings
 # The external encodings may be changed via the phase_rep_format,
@@ -247,6 +245,7 @@ QUBIT_ORDERS = ["right-to-left", "left-to-right"]
 
 
 def _is_pattern(string, pattern):
+    """_summary_"""
     return bool(pattern.search(string))
 
 
@@ -256,31 +255,49 @@ def _is_pattern(string, pattern):
 
 
 def get_phase_encodings() -> List[str]:
+    """_summary_"""
     pass
+
 
 def get_tensor_encodings() -> List[str]:
+    """_summary_"""
     pass
 
+
 def get_pauli_encodings() -> List[str]:
+    """_summary_"""
     pass
+
 
 # -------------------------------------------------------------------------------
 # Encoding Methods and Conversions
 # -------------------------------------------------------------------------------
 
-
+# pylint: disable=unused-argument
 def split_pauli_enc(encoding: str) -> Tuple[str, str]:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _split_pauli_enc(encoding: str) -> Tuple[str, str]:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def get_phase_enc(encoding: str) -> str:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def get_tensor_enc(encoding: str) -> str:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def change_pauli_encoding(
     phase_exp: Any,
     y_count: Union[np.array, int] = 0,
@@ -289,33 +306,52 @@ def change_pauli_encoding(
     output_pauli_encoding: str = DEFAULT_EXTERNAL_XP_PAULI_ENCODING,
     same_type=True,
 ) -> Any:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _change_pauli_encoding(
     phase_exponent: np.ndarray,
     y_count: np.ndarray,
     input_pauli_encoding: str,
     output_pauli_encoding: str,
 ) -> Any:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def stand_phase_str(
     phase_str: str, same_type: bool = True, imaginary: str = "i"
 ) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _stand_phase_str(phase_string: np.ndarray, imaginary: str) -> np.ndarray:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def is_scalar(obj: Any, scalar_pair: bool = False):
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def squeeze(array_: Any, scalar: bool = False) -> bool:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def is_exp_type(phase_exp: Any, input_phase_encoding: str) -> bool:
+    """_summary_"""
     pass
+
 
 # Conversion function between XPPauli phases as
 
@@ -336,140 +372,190 @@ def is_exp_type(phase_exp: Any, input_phase_encoding: str) -> bool:
 # when scalar values are input
 
 # ----------------------------------------------------------------------
+# pylint: disable=unused-argument
 def cpxstr2cpx(
     cpx_str: Union[str, np.ndarray, List[str]],
     same_type: bool = True,
 ) -> Union[np.ndarray, numbers.Complex]:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _cpxstr2cpx(cpx_string: np.ndarray) -> np.ndarray:
+    """_summary_"""
     pass
+
 
 # ----------------------------------------------------------------------
+# pylint: disable=unused-argument
 def cpx2cpxstr(
     cpx: Union[numbers.Complex, np.ndarray], same_type: bool = True, ones: bool = False
 ) -> Union[str, np.ndarray]:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _cpx2cpxstr(cpx: np.ndarray, one_str: str) -> Union[str, np.ndarray]:
+    """_summary_"""
     pass
+
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def exp2cpx(
     phase_exp: Any, input_encoding: str, same_type: bool = True
 ) -> Union[np.ndarray, numbers.Complex]:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _exp2cpx(phase_exp: np.ndarray, input_encoding: str) -> np.ndarray:
+    """_summary_"""
     pass
+
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def cpx2exp(
     cpx: numbers.Complex, output_encoding: str, same_type: bool = True, roundit: bool = True
 ) -> Union[np.ndarray, Tuple[numbers.Integral, numbers.Integral], numbers.Integral]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _cpx2exp(cpx: numbers.Complex, encoding: str) -> np.ndarray:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def expstr2exp(exp_str: Union[np.ndarray, str], same_type: bool = True) -> Any:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _expstr2exp(exp_string, encoding: str) -> np.ndarray:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def exp2expstr(
     phase_exp: Any,
     input_encoding: str,
     same_type: bool = True,
 ) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _exp2expstr(phase_exp: np.ndarray, encoding: str) -> np.ndarray:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def exp2exp(
     phase_exp: Union[np.ndarray, Any],
     input_encoding=INTERNAL_PHASE_ENCODING,
     output_encoding=DEFAULT_EXTERNAL_PHASE_ENCODING,
     same_type: bool = True,
 ):
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _exp2exp(phase_exp, input_encoding, output_encoding):
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def cpxstr2expstr(
     cpx_str: Union[np.ndarray, str], encoding: str, same_type: bool = True
 ) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def expstr2cpxstr(
     exp_str: Union[np.ndarray, str], encoding: str, same_type: bool = True, ones: bool = False
 ) -> Union[str, np.ndarray]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def cpxstr2exp(cpx_str: Union[np.ndarray, str], encoding: str, same_type: bool = True) -> Any:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def exp2cpxstr(
     phase_exp: Any, encoding: str, same_type: bool = True, ones: bool = False
 ) -> Union[str, np.ndarray]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def expstr2cpx(
     phase_str: Union[np.ndarray, str], encoding: str, same_type: bool = True
 ) -> Union[np.ndarray, numbers.Complex]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def cpx2expstr(
     cpx: Union[np.ndarray, numbers.Complex], encoding: str, same_type: bool = True
 ) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def str2exp(
     phase_str: Union[np.ndarray, str], encoding: str, same_type: bool = True
 ) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def _str2exp(phase_str: np.ndarray, encoding: str) -> np.ndarray:
+    """_summary_"""
     pass
 
 
@@ -478,11 +564,15 @@ def _str2exp(phase_str: np.ndarray, encoding: str) -> np.ndarray:
 # ---------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def split_pauli(pauli_str: str, same_type: bool = True) -> Tuple[str, str]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _split_pauli(pauli_str: str):
+    """_summary_"""
 
     def _split(p_str):
         pass
@@ -493,12 +583,17 @@ def _split_pauli(pauli_str: str):
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def encode_of_phase_str(phase_str: str, same_type: bool = True) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _encode_of_phase_str(phase_str: str) -> np.ndarray:
+    """_summary_"""
 
+    # pylint: disable=unused-variable
     def _find_encode(p_str):
         pass
 
@@ -508,15 +603,21 @@ def _encode_of_phase_str(phase_str: str) -> np.ndarray:
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def encode_of_tensor_str(
     tensor_str: str, encoded: bool = True, same_type: bool = True
 ) -> List[Tuple[List, Union[str, int]]]:
+    """_summary_"""
     pass
 
+
+# pylint: disable=unused-argument
 def _encode_of_tensor_str(
     tensor_str: np.ndarray, encoded: bool
 ) -> List[Tuple[List, Union[str, int]]]:
+    """_summary_"""
 
+    # pylint: disable=unused-variable
     def _find_encode(t_str: str, ecode: bool):
         pass
 
@@ -526,6 +627,7 @@ def _encode_of_tensor_str(
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def str2symplectic(
     pauli_str: Union[np.ndarray, str],
     qubit_order: str = "right-to-left",
@@ -533,19 +635,23 @@ def str2symplectic(
     index_start: int = 0,
     same_type: bool = True,
 ) -> Tuple[np.ndarray, Union[np.array, Any]]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _str2symplectic(
     pauli_str: np.ndarray,
     qubit_order: str,
     output_encoding: str,
     index_start: int,
 ) -> Tuple[np.ndarray, np.ndarray]:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
+# pylint: disable=unused-argument
 def symplectic2str(
     matrix: np.ndarray,
     phase_exp: Any = None,
@@ -559,10 +665,12 @@ def symplectic2str(
     same_type=True,
     index_str="",
 ) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
+# pylint: disable=unused-argument
 def str2str(
     pauli_str: Union[np.ndarray, str],
     syntax_output: str,
@@ -573,6 +681,7 @@ def str2str(
     index_start_input: int = 0,
     index_start_output: int = 0,
 ) -> Union[np.ndarray, str]:
+    """_summary_"""
     pass
 
 
@@ -581,20 +690,24 @@ def str2str(
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def from_array(
     matrix: Union[List, Tuple, np.ndarray],
     phase_exp: Union[int, List, Tuple, np.ndarray] = None,
     input_pauli_encoding: Optional[str] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def from_split_array(
     x: Union[List, Tuple, np.ndarray],
     z: Union[List, Tuple, np.ndarray],
     phase_exp: Union[int, List, Tuple, np.ndarray],
     input_pauli_encoding: Optional[str] = None,
 ) -> Tuple[np.ndarray, np.ndarray]:
+    """_summary_"""
     pass
 
 
@@ -603,18 +716,22 @@ def from_split_array(
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def to_cpx_matrix(
     matrix: np.ndarray,
     phase_exp: Optional[np.ndarray],
     pauli_encoding: str = INTERNAL_XP_PAULI_ENCODING,
     sparse: bool = False,
 ) -> Union[np.ndarray, csr_matrix]:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def _to_cpx_matrix(
     matrix: np.ndarray, phase_exp: int, num_qubits: int, sparse: bool = False
 ) -> Union[np.ndarray, csr_matrix]:
+    """_summary_"""
     pass
 
 
@@ -623,31 +740,41 @@ def _to_cpx_matrix(
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def indices_to_boolean(indices: Iterable[int], dim: int) -> np.ndarray:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
+# pylint: disable=unused-argument
 def _ind_to_latex_repr(index: int) -> str:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def boolean_to_indices(booleans: Iterable[bool]) -> np.ndarray:
+    """_summary_"""
     pass
 
 
+# pylint: disable=unused-argument
 def scalar_op2symplectic(
     op: ScalarOp, output_encoding: str = DEFAULT_EXTERNAL_PHASE_ENCODING
 ) -> Tuple[np.ndarray, Union[np.array, Any]]:
+    """_summary_"""
     pass
 
 
 # ----------------------------------------------------------------------
 
 
+# pylint: disable=unused-argument
 def gate2symplectic(
     gate: Gate, encoding: str = INTERNAL_XP_PAULI_ENCODING
 ) -> Tuple[np.ndarray, Union[np.array, Any]]:
+    """_summary_"""
     pass
 
 

--- a/qiskit_qec/utils/xp_pauli_rep.py
+++ b/qiskit_qec/utils/xp_pauli_rep.py
@@ -1,0 +1,654 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+N-qubit XPPauli Representation Encodings and Conversion Module
+"""
+
+# pylint: disable=invalid-name,anomalous-backslash-in-string
+# pylint: disable=bad-docstring-quotes  # for deprecate_function decorator
+
+import numbers
+import re
+from typing import Any, Iterable, List, Optional, Tuple, Union
+
+import numpy as np
+from qiskit.circuit import Gate
+from qiskit.circuit.library.generalized_gates import PauliGate
+from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
+from qiskit.exceptions import QiskitError
+from qiskit.quantum_info.operators.scalar_op import ScalarOp
+from scipy.sparse import csr_matrix
+from qiskit_qec.linear.symplectic import count_num_y, is_symplectic_matrix_form
+
+
+# -------------------------------------------------------------------------------
+# Module Variables/States
+# -------------------------------------------------------------------------------
+
+# Set the interal encodings
+# The internal encoding cannot be changed by changing this constant
+# These constants are for reference only and do not change the behavior of
+# the XPPauli methods. See [ref] for details on the different encodings
+# TODO: Include ref for above.
+
+INTERNAL_TENSOR_ENCODING = "ZX"
+INTERNAL_PHASE_ENCODING = "-i"
+INTERNAL_XP_PAULI_ENCODING = INTERNAL_PHASE_ENCODING + INTERNAL_TENSOR_ENCODING
+
+DEFAULT_EXTERNAL_TENSOR_ENCODING = "YZX"
+DEFAULT_EXTERNAL_PHASE_ENCODING = "-i"
+DEFAULT_EXTERNAL_XP_PAULI_ENCODING = DEFAULT_EXTERNAL_PHASE_ENCODING + DEFAULT_EXTERNAL_TENSOR_ENCODING
+
+# Set the external encodings
+# The external encodings may be changed via the phase_rep_format,
+# symp_rep_format, or pauli_rep_format methods. Any method changing
+# these values must make sure to update the others
+# Tensor encodings are: 'XZ', 'XZY', 'ZX', 'YZX'
+# Phase encodings are: 'i', '-i', 'is', '-is'
+# See [ref] for details on the different encodings
+# TODO: Include ref for above.
+
+PHASE_ENCODINGS = ["i", "-i", "is", "-is"]
+PHASE_ENCODINGS_IMI = ["i", "-i"]
+PHASE_ENCODINGS_ISMIS = ["is", "-is"]
+TENSOR_ENCODINGS = ["XZ", "XZY", "ZX", "YZX"]
+Y_TENSOR_ENCODINGS = ["XZY", "YZX"]
+XP_PAULI_ENCODINGS = [
+    "iXZ",
+    "iXZY",
+    "iZX",
+    "iYZX",
+    "-iXZ",
+    "-iXZY",
+    "-iZX",
+    "-iYZX",
+    "isXZ",
+    "isXZY",
+    "isZX",
+    "isYZX",
+    "-isXZ",
+    "-isXZY",
+    "-isZX",
+    "-isYZX",
+]
+XP_PAULI_ENCODINGS_SPLIT = {
+    "iXZ": ("i", "XZ"),
+    "iXZY": ("i", "XZY"),
+    "iZX": ("i", "ZX"),
+    "iYZX": ("i", "YZX"),
+    "-iXZ": ("-i", "XZ"),
+    "-iXZY": ("-i", "XZY"),
+    "-iZX": ("-i", "ZX"),
+    "-iYZX": ("-i", "YZX"),
+    "isXZ": ("is", "XZ"),
+    "isXZY": ("is", "XZY"),
+    "isZX": ("is", "ZX"),
+    "isYZX": ("is", "YZX"),
+    "-isXZ": ("-is", "XZ"),
+    "-isXZY": ("-is", "XZY"),
+    "-isZX": ("-is", "ZX"),
+    "-isYZX": ("-is", "YZX"),
+}
+
+# Different string syntax formats are available. The they are "product" syntax and
+# "index" syntax. "product" syntax represents a XPPauli operator of the form
+# :math: $p * T_1 \otimes T_2 \otimes ... \otimes T_n$ as :math" $pT1T2T3...Tn$. See the
+# following exmaples:
+#
+# -iX \otimes Y \otimes Z -> -iXYZ
+# X \otimes Y \otimes Z \otimes I \otimes I \otimes I  -> XYZII
+#
+# The index syntax only represents the non identity XPPaulis. Index syntax specifically
+# indiciates the index that the XPPauli's are acting on. Following Qiskit's current internal
+# indexing:
+#
+# -iX \otimes Y \otimes Z -> -iZ0Y1X2
+# X \otimes Y \otimes Z \otimes I \otimes I \otimes I  -> Z3Y4X5
+
+# -i, -1j, +1, ...
+COMPLEX_REGEX = r"[\-+]?1?[ij]?"
+# (i,2), (1j, 0), ( +i , 2 ), ...
+ENC_I_REGEX = r"\(\s*[+]?[ij]\s*\,\s*[0123]\s*\)"
+# (-i,2), (-1j, 0), ( -i , 2 ), ...
+ENC_MI_REGEX = r"\(\s*\-1?[ij]\s*\,\s*[0123]\s*\)"
+# (i,0)(-1,1), (1j,1)(-1 , 0), ...
+ENC_IS_REGEX = r"\(\s*1?[ij]\s*\,\s*[01]\s*\)\s*\(\s*\-1\s*\,\s*[01]\s*\)"
+# (-i,0)(-1,1), (-1j,1)(-1, 0), ...
+ENC_MIS_REGEX = r"\(\s*\-1?[ij]\s*\,\s*[01]\s*\)\s*\(\s*\-1\s*\,\s*[01]\s*\)"
+
+CAP_STAND_ENC_I_REGEX = r"\(i\,([0123])\)"
+CAP_STAND_ENC_MI_REGEX = r"\(-i\,([0123])\)"
+CAP_STAND_ENC_IS_REGEX = r"\(i\,([01])\)\(-1\,([01])\)"
+CAP_STAND_ENC_MIS_REGEX = r"\(-i\,([01])\)\(-1\,([01])\)"
+
+CAP_STAND_I_PATTERN = re.compile(f"^{CAP_STAND_ENC_I_REGEX}$")
+CAP_STAND_MI_PATTERN = re.compile(f"^{CAP_STAND_ENC_MI_REGEX}$")
+CAP_STAND_IS_PATTERN = re.compile(f"^{CAP_STAND_ENC_IS_REGEX}$")
+CAP_STAND_MIS_PATTERN = re.compile(f"^{CAP_STAND_ENC_MIS_REGEX}$")
+
+CAP_PHASE_PATTERN = {
+    "i": CAP_STAND_I_PATTERN,
+    "-i": CAP_STAND_MI_PATTERN,
+    "is": CAP_STAND_IS_PATTERN,
+    "-is": CAP_STAND_MIS_PATTERN,
+}
+
+COMPLEX_PATTERN = re.compile(f"^({COMPLEX_REGEX})$")
+
+I_PATTERN = re.compile(f"^({ENC_I_REGEX})$")
+MI_PATTERN = re.compile(f"^({ENC_MI_REGEX})$")
+IS_PATTERN = re.compile(f"^({ENC_IS_REGEX})$")
+MIS_PATTERN = re.compile(f"^({ENC_MIS_REGEX})$")
+
+PHASE_PATTERN = {
+    "complex": COMPLEX_PATTERN,
+    "i": I_PATTERN,
+    "-i": MI_PATTERN,
+    "is": IS_PATTERN,
+    "-is": MIS_PATTERN,
+}
+
+XP_PAULI_START_REGEX = r"\(?[IXZY].*"
+SPLIT_PATTERN = re.compile(f"^(.*?)({XP_PAULI_START_REGEX})")
+
+PHASE_REGEX = r"[\-+]?1?[ij]?"
+XP_PAULI_REGEX = r"[IXZY]"
+
+INDEX_REGEX = r".*?[0-9].*"
+INDEX_INDICATE_PATTERN = re.compile(f"^{INDEX_REGEX}$")
+
+LATEX_REGEX = r".*?_\{[0-9].*"
+LATEX_INDICATE_PATTERN = re.compile(f"^{LATEX_REGEX}$")
+
+
+ENC_INDEX_XZ_REGEX = r"(\((X[0-9]+|Z[0-9]+|X([0-9]+)Z\3)\))+"
+ENC_INDEX_XZY_REGEX = r"([XZY][0-9]+)+"
+ENC_INDEX_ZX_REGEX = r"(\((X[0-9]+|Z[0-9]+|Z([0-9]+)X\3)\))+"
+ENC_INDEX_YZX_REGEX = r"([XZY][0-9]+)+"
+
+
+INDEX_XZ_PATTERN_CAP = re.compile(r"\((X[0-9]+|Z[0-9]+|X(?:[0-9]+)Z[0-9]+)\)")
+INDEX_ZX_PATTERN_CAP = re.compile(r"\((Z[0-9]+|X[0-9]+|Z(?:[0-9]+)X[0-9]+)\)")
+
+INDEX_XZ_PATTERN = re.compile(f"^{ENC_INDEX_XZ_REGEX}$")
+INDEX_XZY_PATTERN = re.compile(f"^{ENC_INDEX_XZY_REGEX}$")
+INDEX_ZX_PATTERN = re.compile(f"^{ENC_INDEX_ZX_REGEX}$")
+INDEX_YZX_PATTERN = re.compile(f"^{ENC_INDEX_YZX_REGEX}$")
+
+TENSOR_INDEX_PATTERN = {
+    "XZ": INDEX_XZ_PATTERN,
+    "XZY": INDEX_XZY_PATTERN,
+    "ZX": INDEX_ZX_PATTERN,
+    "YZX": INDEX_YZX_PATTERN,
+}
+
+ENC_LATEX_XZ_REGEX = r"(\((X_\{[0-9]+\}|Z_\{[0-9]+\}|X_\{([0-9]+\})Z\3)\))+"
+ENC_LATEX_XZY_REGEX = r"([XZY]_\{[0-9]+\})+"
+ENC_LATEX_ZX_REGEX = r"(\((X_\{[0-9]+\}|Z_\{[0-9]+\}|Z_\{([0-9]+\})X\3)\))+"
+ENC_LATEX_YZX_REGEX = r"([XZY]_\{[0-9]+\})+"
+
+
+LATEX_XZ_PATTERN_CAP = re.compile(r"\((X_\{[0-9]+\}|Z_\{[0-9]+\}|X(?:_\{[0-9]+\})Z_\{[0-9]+\})\)")
+LATEX_ZX_PATTERN_CAP = re.compile(r"\((Z_\{[0-9]+\}|X_\{[0-9]+\}|Z(?:_\{[0-9]+\})X_\{[0-9]+\})\)")
+
+LATEX_XZ_PATTERN = re.compile(f"^{ENC_LATEX_XZ_REGEX}$")
+LATEX_XZY_PATTERN = re.compile(f"^{ENC_LATEX_XZY_REGEX}$")
+LATEX_ZX_PATTERN = re.compile(f"^{ENC_LATEX_ZX_REGEX}$")
+LATEX_YZX_PATTERN = re.compile(f"^{ENC_LATEX_YZX_REGEX}$")
+
+TENSOR_LATEX_PATTERN = {
+    "XZ": LATEX_XZ_PATTERN,
+    "XZY": LATEX_XZY_PATTERN,
+    "ZX": LATEX_ZX_PATTERN,
+    "YZX": LATEX_YZX_PATTERN,
+}
+
+
+ENC_PRODUCT_XZ_CAP = r"\(([XZ]|XZ|I)\)"
+ENC_PRODUCT_ZX_CAP = r"\(([ZX]|ZX|I)\)"
+
+PRODUCT_XZ_PATTERN_CAP = re.compile(f"{ENC_PRODUCT_XZ_CAP}")
+PRODUCT_ZX_PATTERN_CAP = re.compile(f"{ENC_PRODUCT_ZX_CAP}")
+
+ENC_PRODUCT_XZ_REGEX = r"(\(([XZ]|XZ|I)\))+"
+ENC_PRODUCT_XZY_REGEX = r"[XZYI]+"
+ENC_PRODUCT_ZX_REGEX = r"(\(([ZX]|ZX|I)\))+"
+ENC_PRODUCT_YZX_REGEX = r"[XZYI]+"
+
+PRODUCT_XZ_PATTERN = re.compile(f"^{ENC_PRODUCT_XZ_REGEX}$")
+PRODUCT_XZY_PATTERN = re.compile(f"^{ENC_PRODUCT_XZY_REGEX}$")
+PRODUCT_ZX_PATTERN = re.compile(f"^{ENC_PRODUCT_ZX_REGEX}$")
+PRODUCT_YZX_PATTERN = re.compile(f"^{ENC_PRODUCT_YZX_REGEX}$")
+
+TENSOR_PRODUCT_PATTERN = {
+    "XZ": PRODUCT_XZ_PATTERN,
+    "XZY": PRODUCT_XZY_PATTERN,
+    "ZX": PRODUCT_ZX_PATTERN,
+    "YZX": PRODUCT_YZX_PATTERN,
+}
+
+PRODUCT_SYNTAX = 0
+INDEX_SYNTAX = 1
+LATEX_SYNTAX = 2
+DEFAULT_SYNTAX = 0
+SYNTAX_TO_TEXT = ["product", "index"]
+
+DEFAULT_QUBIT_ORDER = "right-to-left"
+QUBIT_ORDERS = ["right-to-left", "left-to-right"]
+
+
+def _is_pattern(string, pattern):
+    return bool(pattern.search(string))
+
+
+# -------------------------------------------------------------------------------
+# Encoding lists
+# -------------------------------------------------------------------------------
+
+
+def get_phase_encodings() -> List[str]:
+    pass
+
+def get_tensor_encodings() -> List[str]:
+    pass
+
+def get_pauli_encodings() -> List[str]:
+    pass
+
+# -------------------------------------------------------------------------------
+# Encoding Methods and Conversions
+# -------------------------------------------------------------------------------
+
+
+def split_pauli_enc(encoding: str) -> Tuple[str, str]:
+    pass
+
+def _split_pauli_enc(encoding: str) -> Tuple[str, str]:
+    pass
+
+def get_phase_enc(encoding: str) -> str:
+    pass
+
+def get_tensor_enc(encoding: str) -> str:
+    pass
+
+def change_pauli_encoding(
+    phase_exp: Any,
+    y_count: Union[np.array, int] = 0,
+    *,
+    input_pauli_encoding: str = INTERNAL_XP_PAULI_ENCODING,
+    output_pauli_encoding: str = DEFAULT_EXTERNAL_XP_PAULI_ENCODING,
+    same_type=True,
+) -> Any:
+    pass
+
+def _change_pauli_encoding(
+    phase_exponent: np.ndarray,
+    y_count: np.ndarray,
+    input_pauli_encoding: str,
+    output_pauli_encoding: str,
+) -> Any:
+    pass
+
+
+def stand_phase_str(
+    phase_str: str, same_type: bool = True, imaginary: str = "i"
+) -> Union[np.ndarray, str]:
+    pass
+
+def _stand_phase_str(phase_string: np.ndarray, imaginary: str) -> np.ndarray:
+    pass
+
+def is_scalar(obj: Any, scalar_pair: bool = False):
+    pass
+
+def squeeze(array_: Any, scalar: bool = False) -> bool:
+    pass
+
+def is_exp_type(phase_exp: Any, input_phase_encoding: str) -> bool:
+    pass
+
+# Conversion function between XPPauli phases as
+
+# complex string: "0-1j", ...
+# complex type: 0-1j, ...
+# encoded string: "(-i, 1)", ...
+# encoded type: (-i,0)(-1,1), ...
+
+# Methods convering between type do not change the encoding scheme if present
+# Encoding schemes can be change via the exp2exp method
+
+# This method are all vector enabled and have two forms: method and _method.
+# The method versions have all the checks and conversions in them. The raw
+# methods assume correct input formats and generally do very little checking
+# or conversions.
+#
+# The same_type parameter is used to allow scalar values to be output
+# when scalar values are input
+
+# ----------------------------------------------------------------------
+def cpxstr2cpx(
+    cpx_str: Union[str, np.ndarray, List[str]],
+    same_type: bool = True,
+) -> Union[np.ndarray, numbers.Complex]:
+    pass
+
+def _cpxstr2cpx(cpx_string: np.ndarray) -> np.ndarray:
+    pass
+
+# ----------------------------------------------------------------------
+def cpx2cpxstr(
+    cpx: Union[numbers.Complex, np.ndarray], same_type: bool = True, ones: bool = False
+) -> Union[str, np.ndarray]:
+    pass
+
+def _cpx2cpxstr(cpx: np.ndarray, one_str: str) -> Union[str, np.ndarray]:
+    pass
+
+# ----------------------------------------------------------------------
+
+
+def exp2cpx(
+    phase_exp: Any, input_encoding: str, same_type: bool = True
+) -> Union[np.ndarray, numbers.Complex]:
+    pass
+
+def _exp2cpx(phase_exp: np.ndarray, input_encoding: str) -> np.ndarray:
+    pass
+
+# ----------------------------------------------------------------------
+
+
+def cpx2exp(
+    cpx: numbers.Complex, output_encoding: str, same_type: bool = True, roundit: bool = True
+) -> Union[np.ndarray, Tuple[numbers.Integral, numbers.Integral], numbers.Integral]:
+    pass
+
+
+def _cpx2exp(cpx: numbers.Complex, encoding: str) -> np.ndarray:
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def expstr2exp(exp_str: Union[np.ndarray, str], same_type: bool = True) -> Any:
+    pass
+
+
+def _expstr2exp(exp_string, encoding: str) -> np.ndarray:
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def exp2expstr(
+    phase_exp: Any,
+    input_encoding: str,
+    same_type: bool = True,
+) -> Union[np.ndarray, str]:
+    pass
+
+
+def _exp2expstr(phase_exp: np.ndarray, encoding: str) -> np.ndarray:
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def exp2exp(
+    phase_exp: Union[np.ndarray, Any],
+    input_encoding=INTERNAL_PHASE_ENCODING,
+    output_encoding=DEFAULT_EXTERNAL_PHASE_ENCODING,
+    same_type: bool = True,
+):
+    pass
+
+
+def _exp2exp(phase_exp, input_encoding, output_encoding):
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def cpxstr2expstr(
+    cpx_str: Union[np.ndarray, str], encoding: str, same_type: bool = True
+) -> Union[np.ndarray, str]:
+    pass
+
+
+def expstr2cpxstr(
+    exp_str: Union[np.ndarray, str], encoding: str, same_type: bool = True, ones: bool = False
+) -> Union[str, np.ndarray]:
+    pass
+
+
+def cpxstr2exp(cpx_str: Union[np.ndarray, str], encoding: str, same_type: bool = True) -> Any:
+    pass
+
+
+def exp2cpxstr(
+    phase_exp: Any, encoding: str, same_type: bool = True, ones: bool = False
+) -> Union[str, np.ndarray]:
+    pass
+
+
+def expstr2cpx(
+    phase_str: Union[np.ndarray, str], encoding: str, same_type: bool = True
+) -> Union[np.ndarray, numbers.Complex]:
+    pass
+
+
+def cpx2expstr(
+    cpx: Union[np.ndarray, numbers.Complex], encoding: str, same_type: bool = True
+) -> Union[np.ndarray, str]:
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def str2exp(
+    phase_str: Union[np.ndarray, str], encoding: str, same_type: bool = True
+) -> Union[np.ndarray, str]:
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def _str2exp(phase_str: np.ndarray, encoding: str) -> np.ndarray:
+    pass
+
+
+# ---------------------------------------------------------------------
+# Label parsing helper functions
+# ---------------------------------------------------------------------
+
+
+def split_pauli(pauli_str: str, same_type: bool = True) -> Tuple[str, str]:
+    pass
+
+
+def _split_pauli(pauli_str: str):
+
+    def _split(p_str):
+        pass
+
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def encode_of_phase_str(phase_str: str, same_type: bool = True) -> Union[np.ndarray, str]:
+    pass
+
+
+def _encode_of_phase_str(phase_str: str) -> np.ndarray:
+
+    def _find_encode(p_str):
+        pass
+
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def encode_of_tensor_str(
+    tensor_str: str, encoded: bool = True, same_type: bool = True
+) -> List[Tuple[List, Union[str, int]]]:
+    pass
+
+def _encode_of_tensor_str(
+    tensor_str: np.ndarray, encoded: bool
+) -> List[Tuple[List, Union[str, int]]]:
+
+    def _find_encode(t_str: str, ecode: bool):
+        pass
+
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def str2symplectic(
+    pauli_str: Union[np.ndarray, str],
+    qubit_order: str = "right-to-left",
+    output_encoding: Optional[str] = INTERNAL_XP_PAULI_ENCODING,
+    index_start: int = 0,
+    same_type: bool = True,
+) -> Tuple[np.ndarray, Union[np.array, Any]]:
+    pass
+
+
+def _str2symplectic(
+    pauli_str: np.ndarray,
+    qubit_order: str,
+    output_encoding: str,
+    index_start: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    pass
+
+
+# ----------------------------------------------------------------------
+def symplectic2str(
+    matrix: np.ndarray,
+    phase_exp: Any = None,
+    input_encoding: str = INTERNAL_XP_PAULI_ENCODING,
+    output_phase_encoding: str = None,
+    no_phase=False,
+    output_tensor_encoding: str = DEFAULT_EXTERNAL_TENSOR_ENCODING,
+    syntax: str = INDEX_SYNTAX,
+    qubit_order: str = "right-to-left",
+    index_start: int = 0,
+    same_type=True,
+    index_str="",
+) -> Union[np.ndarray, str]:
+    pass
+
+
+# ----------------------------------------------------------------------
+def str2str(
+    pauli_str: Union[np.ndarray, str],
+    syntax_output: str,
+    phase_encoding_output_string: str = None,
+    tensor_encoding_output_string: str = DEFAULT_EXTERNAL_TENSOR_ENCODING,
+    qubit_order_input: str = "right-to-left",
+    qubit_order_output: str = "right-to-left",
+    index_start_input: int = 0,
+    index_start_output: int = 0,
+) -> Union[np.ndarray, str]:
+    pass
+
+
+# ----------------------------------------------------------------------
+# Array(s) to Symplectic
+# ----------------------------------------------------------------------
+
+
+def from_array(
+    matrix: Union[List, Tuple, np.ndarray],
+    phase_exp: Union[int, List, Tuple, np.ndarray] = None,
+    input_pauli_encoding: Optional[str] = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    pass
+
+
+def from_split_array(
+    x: Union[List, Tuple, np.ndarray],
+    z: Union[List, Tuple, np.ndarray],
+    phase_exp: Union[int, List, Tuple, np.ndarray],
+    input_pauli_encoding: Optional[str] = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    pass
+
+
+# ----------------------------------------------------------------------
+# Symplectic to Complex Matrix conversion
+# ----------------------------------------------------------------------
+
+
+def to_cpx_matrix(
+    matrix: np.ndarray,
+    phase_exp: Optional[np.ndarray],
+    pauli_encoding: str = INTERNAL_XP_PAULI_ENCODING,
+    sparse: bool = False,
+) -> Union[np.ndarray, csr_matrix]:
+    pass
+
+
+def _to_cpx_matrix(
+    matrix: np.ndarray, phase_exp: int, num_qubits: int, sparse: bool = False
+) -> Union[np.ndarray, csr_matrix]:
+    pass
+
+
+# ----------------------------------------------------------------------
+# Utility functions
+# ----------------------------------------------------------------------
+
+
+def indices_to_boolean(indices: Iterable[int], dim: int) -> np.ndarray:
+    pass
+
+
+# ----------------------------------------------------------------------
+def _ind_to_latex_repr(index: int) -> str:
+    pass
+
+
+def boolean_to_indices(booleans: Iterable[bool]) -> np.ndarray:
+    pass
+
+
+def scalar_op2symplectic(
+    op: ScalarOp, output_encoding: str = DEFAULT_EXTERNAL_PHASE_ENCODING
+) -> Tuple[np.ndarray, Union[np.array, Any]]:
+    pass
+
+
+# ----------------------------------------------------------------------
+
+
+def gate2symplectic(
+    gate: Gate, encoding: str = INTERNAL_XP_PAULI_ENCODING
+) -> Tuple[np.ndarray, Union[np.array, Any]]:
+    pass
+
+
+# ----------------------------------------------------------------------


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix for issue #258 . Added skeleton class `BaseXPPauli` and methods `xp_pauli_rep.py`


### Details and comments
- Added skeleton class and methods in qiskit_qec/operators and qiskit_qec/utils
- Most function declarations from `BasePauli` and `pauli_rep.py` have been retained as of now. Functions are empty. There are placeholders for future documentation.
- Locally disabled lint warnings for newly added files
- Fixed a typo

