### PR TITLE
Use PyMatching 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit-terra>=0.21.2
 qiskit-aer>=0.11.0
 pybind11<=2.9.1
-PyMatching==0.7.0
+PyMatching>=0.6.0,<0.7.0
 rustworkx>=0.11.0
 networkx>=2.6.3
 sympy>=1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit-terra>=0.21.2
 qiskit-aer>=0.11.0
 pybind11<=2.9.1
-PyMatching>=0.6.0
+PyMatching==0.7.0
 rustworkx>=0.11.0
 networkx>=2.6.3
 sympy>=1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit-terra>=0.21.2
 qiskit-aer>=0.11.0
 pybind11<=2.9.1
-PyMatching>=0.6.0,<0.7.0
+PyMatching>=0.6.0,<=0.7.0
 rustworkx>=0.11.0
 networkx>=2.6.3
 sympy>=1.9


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ x] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

Updates the requirements to use the last version of PyMatching, to avoid failures that occur for the most recent.

### Details and comments

This should deal with issue #276. But probably best to leave that issue there until a more permanent fix is found, which updates qiskit-qec to the most recent PyMatching.