### PR TITLE
Make qiskit-qec compatible with pymatching v2

### DIFF
--- a/qiskit_qec/decoders/circuit_matching_decoder.py
+++ b/qiskit_qec/decoders/circuit_matching_decoder.py
@@ -304,18 +304,9 @@ class CircuitModelMatchingDecoder(ABC):
         for source, target in graph.edge_list():
             edge_data = graph.get_edge_data(source, target)
             if "weight_poly" not in edge_data and edge_data["weight"] != 0:
-                if (
-                    "is_boundary" in graph.nodes()[source] and graph.nodes()[source]["is_boundary"]
-                ) or (
-                    "is_boundary" in graph.nodes()[target] and graph.nodes()[target]["is_boundary"]
-                ):
-                    # TODO: we could consider removing the edge
-                    edge_data["weight"] = 1000000
-                    logging.info("increase edge weight (%d, %d)", source, target)
-                else:
-                    # Otherwise, remove the edge
-                    remove_list.append((source, target))
-                    logging.info("remove edge (%d, %d)", source, target)
+                # Remove the edge
+                remove_list.append((source, target))
+                logging.info("remove edge (%d, %d)", source, target)
         graph.remove_edges_from(remove_list)
         return graph
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 qiskit-terra>=0.21.2
 qiskit-aer>=0.11.0
 pybind11<=2.9.1
-PyMatching>=0.6.0
+PyMatching>=0.6.0,!=2.0.0
 rustworkx>=0.11.0
 networkx>=2.6.3
 sympy>=1.9

--- a/tests/matching/test_circuitmatcher.py
+++ b/tests/matching/test_circuitmatcher.py
@@ -352,7 +352,12 @@ class TestCircuitMatcher(unittest.TestCase):
             corrected_outcomes = dec.process(outcome)
             fail = temp_syndrome(corrected_outcomes, self.z_logical)
             failures += fail[0]
-        self.assertEqual(failures, 156)
+        # For pymatching v0.x, there are 168 failures, whereas for pymatching >v2.0.0 there are 156.
+        # The reason for the difference is that many of these test cases have degenerate solutions
+        # (Both versions of pymatching are giving valid minimum-weight perfect matching solutions, but
+        # the predictions they make are not always the same when there is more than one valid
+        # minimum-weight solution.)
+        self.assertTrue(failures in {156, 168})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes issue #276 and is intended to supersede PR #278

### Details and comments

* Changes pymatching dependency in the `requirements.txt` from `PyMatching>=0.6.0` to `PyMatching>=0.6.0,!=2.0.0`
* Fixes a test which failed for the new pymatching patch release v2.0.1 (v2.0.1 is a patch release that fixes an issue causing tests in #276 to fail with v2.0.0). All tests now pass with pymatching v2.0.1 (as well as v0.7 still)
* Removes edges in `qiskit_qec.decoders.circuit_matching_decoder.CircuitModelMatchingDecoder._revise_decoding_graph` where previously they were assigned high weights. It's always best to remove edges rather than assigning them large weights where possible. In pymatching v2, edge weights are rescaled to integers with a maximum absolute value of 2^24 internally when being processed by the decoder. 24 bits of precision is plenty for matching graphs, where edge weights are typically log-likelihood ratios with absolute values not exceeding 10. However, if you add an edge with weight 1000000 then the discretisation becomes much coarser than it needs to for the remaining small edge weights. PyMatching raises a warning if you add an edge with weight larger than 2^24 (and won't add the edge), but 1000000 isn't large enough for that to kick in. Anyway, easiest just to remove the edges...