### PR TITLE
274 building xppauli classes (part of 257)

### DIFF
--- a/qiskit_qec/operators/__init__.py
+++ b/qiskit_qec/operators/__init__.py
@@ -35,3 +35,4 @@ from .pauli import Pauli
 from .pauli_list import PauliList
 from .base_xp_pauli import BaseXPPauli
 from .xp_pauli import XPPauli
+from .xp_pauli_list import XPPauliList

--- a/qiskit_qec/operators/__init__.py
+++ b/qiskit_qec/operators/__init__.py
@@ -34,3 +34,4 @@ from .base_pauli import BasePauli
 from .pauli import Pauli
 from .pauli_list import PauliList
 from .base_xp_pauli import BaseXPPauli
+from .xp_pauli import XPPauli

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -310,6 +310,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         Raises:
             QiskitError: if number of qubits of other does not match qargs.
+
+        See also:
+            _compose
         """
 
         # Validation
@@ -339,13 +342,6 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     ) -> "BaseXPPauli":
         """Returns the composition of two BaseXPPauli objects.
 
-        Args:
-            a : BaseXPPauli object
-            b : BaseXPPauli object
-            qargs (Optional[list], optional): _description_. Defaults to None.
-            front (bool, optional): _description_. Defaults to False.
-            inplace (bool, optional): _description_. Defaults to False.
-
         Note:
             This method is adapted from method XPMul from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
@@ -353,8 +349,18 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
 
+        Args:
+            a : BaseXPPauli object
+            b : BaseXPPauli object
+            qargs (Optional[list], optional): _description_. Defaults to None.
+            front (bool, optional): _description_. Defaults to False.
+            inplace (bool, optional): _description_. Defaults to False.
+
         Returns:
             BaseXPPauli: _description_
+
+        See also:
+            unique_vector_rep, _unique_vector_rep
         """
 
         assert a.precision == b.precision, QiskitError(
@@ -546,6 +552,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _unique_vector_rep
         """
         return self._unique_vector_rep()
 
@@ -578,6 +587,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _rescale_precision
         """
         return self._rescale_precision(new_precision)
 
@@ -592,6 +604,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            unique_vector_rep
         """
 
         # TODO Currently, if any operator in an XPPauliList can not be
@@ -632,6 +647,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _weight
         """
         return self._weight()
 
@@ -657,6 +675,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _is_diagonal
         """
         return self._is_diagonal()
 
@@ -681,6 +702,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _antisymmetric_op
         """
         return self._antisymmetric_op()
 
@@ -716,6 +740,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _power
         """
         return self._power(n)
 
@@ -729,6 +756,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _unique_vector_rep
         """
         # TODO at present, this function only handles positive powers. If it is
         # supposed to calculate inverses as well, that functionality needs to
@@ -765,6 +795,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _degree
         """
         return self._degree()
 
@@ -777,6 +810,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            is_diagonal
         """
 
         gcd = np.gcd(self.z, self.precision)

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -521,11 +521,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # BaseXPPauli methods for XP arithmetic
     # ---------------------------------------------------------------------
 
-    def unique_vector_rep(self):
+    def unique_vector_rep(self) -> "BaseXPPauli":
         """_summary_"""
         return self._unique_vector_rep()
 
-    def _unique_vector_rep(self):
+    def _unique_vector_rep(self) -> "BaseXPPauli":
         """(TODO improve doc): This is the equivalent of XPRound from Mark's
         code. It converts the XPPauli operator into unique vector form, ie
         phase_exp in Z modulo 2*precision, x in Z_2, z in Z modulo
@@ -538,11 +538,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         return BaseXPPauli(matrix, phase_exp, self.precision)
 
-    def rescale_precision(self, new_precision):
+    def rescale_precision(self, new_precision: int) -> "BaseXPPauli":
         """_summary_"""
         return self._rescale_precision(new_precision)
 
-    def _rescale_precision(self, new_precision):
+    def _rescale_precision(self, new_precision: int) -> "BaseXPPauli":
         """(TODO improve doc): This is the equivalent of XPSetNsingle from
         Mark's code. It rescales the generalized symplectic vector components
         of XPPauli operator to the new precision. Returns None if the
@@ -577,36 +577,37 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         return BaseXPPauli(matrix, phase_exp, new_precision)
 
-    def weight(self):
+    def weight(self) -> Union[int, np.ndarray]:
         """_summary_"""
         return self._weight()
 
-    def _weight(self):
+    def _weight(self) -> Union[int, np.ndarray]:
         """(TODO improve doc) This is the equivalent of XPDistance function
         from Mark's code. It returns the count of qubits where either z or x
         component is nonzero."""
         return np.sum(np.logical_or(self.x, self.z), axis=-1)
 
-    def is_diagonal(self):
+    def is_diagonal(self) -> np.ndarray:
         """_summary_"""
         return self._is_diagonal()
 
-    def _is_diagonal(self):
+    def _is_diagonal(self) -> np.ndarray:
         """(TODO improve doc) This is the equivalent of XPisDiag function from
         Mark's code. Returns True if the XP operator is diagonal."""
         return np.where(np.sum(self.x, axis=-1) == 0, True, False)
 
-    def antisymmetric_op(self):
+    def antisymmetric_op(self) -> "BaseXPPauli":
         """_summary_"""
         return self._antisymmetric_op()
 
-    def _antisymmetric_op(self):
+    def _antisymmetric_op(self) -> "BaseXPPauli":
         """(TODO improve doc) This is the equivalent of XPD function from
         Mark's code. It returns the antisymmetric operator corresponding to the
         z component of XP operator, only if x component is 0, else it returns
         None."""
 
         if np.any(self.x):
+            # TODO should there be an assertion here?
             return None
 
         phase_exp = np.sum(self.z, axis=-1)
@@ -615,11 +616,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         return BaseXPPauli(matrix=matrix, phase_exp=phase_exp, precision=self.precision)
 
-    def power(self, n):
+    def power(self, n: int) -> "BaseXPPauli":
         """_summary_"""
         return self._power(n)
 
-    def _power(self, n):
+    def _power(self, n: int) -> "BaseXPPauli":
         """(TODO improve doc) This is te equivalent of XPPower function from
         Mark's code. It returns the XP operator of specified precision raised
         to the power n."""
@@ -649,11 +650,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         return product._unique_vector_rep()
 
-    def degree(self):
+    def degree(self) -> np.ndarray:
         """_summary_"""
         return self._degree()
 
-    def _degree(self):
+    def _degree(self) -> np.ndarray:
         """(TODO improve doc) This is the equivalent of XPDegree from Mark's
         code. It returns the degree of XP operator."""
 
@@ -672,11 +673,12 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         lcm_square = 2 * lcm_square
 
-        # TODO it can be explored (maybe with Mark) if the algorithm used when
-        # the XP operator is non-diagonal (which involves squaring) gives the
-        # correct output for diagonal XP operators as well (naively that seems
-        # to be true). If that is the case, then checking np.where and
-        # is_diagonal can be removed and the code can be optimized a bit.
+        # Do not modify the logic of this function. Naively, it looks like the
+        # algorithm that is used when the XP operator is non-diagonal (which
+        # involves squaring) gives the correct output for diagonal XP operators
+        # as well. However, that is not true. Counter example given by Mark
+        # Webster is the operator -I, where the faulty method would give the
+        # degree 2, while the actual degree is 1.
         return np.where(self.is_diagonal(), lcm, lcm_square)
 
 

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -94,7 +94,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             >>> base_xp_pauli = BaseXPPauli(matrix)
 
         See Also:
-            Pauli, PauliList
+            XPPauli, XPPauliList
         """
 
         if not (isinstance(precision, int) and (precision > 1)):
@@ -311,6 +311,15 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         Raises:
             QiskitError: if number of qubits of other does not match qargs, or
                          if precision of other does not match precision of self.
+       
+        Examples:
+            >>> a = BaseXPPauli(matrix=np.array([0, 1, 0, 0, 2, 0], dtype=np.int64), phase_exp=6, precision=4)
+            >>> b = BaseXPPauli(matrix=np.array([1, 1, 1, 3, 3, 0], dtype=np.int64), phase_exp=2, precision=4)
+            >>> value = BaseXPPauli.compose(a, b)
+            >>> value.matrix
+            array([[1, 0, 1, 3, 3, 0]], dtype=int64)
+            >>> value._phase_exp
+            array([6])
 
         See also:
             _compose
@@ -559,6 +568,14 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         Returns:
             BaseXPPauli: Unique vector representation of self
 
+        Examples:
+            >>> a = BaseXPPauli(matrix=np.array([0, 3, 1, 6, 4, 3], dtype=np.int64), phase_exp=11, precision=4)
+            >>> a = a.unique_vector_rep()
+            >>> a.matrix
+            np.array([[0, 1, 1, 2, 0, 3]], dtype=int64)
+            >>> a._phase_exp
+            array([3], dtype=int32)
+
         See also:
             _unique_vector_rep
         """
@@ -607,6 +624,14 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         Raises:
             QiskitError: If it is not possible to express BaseXPPauli in new_precision 
+        
+        Examples:
+            >>> a = BaseXPPauli(matrix=np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64), phase_exp=12, precision=8)
+            >>> a = a.rescale_precision(new_precision=2)
+            >>> a.matrix
+            array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]], dtype=int64)
+            >>> a._phase_exp
+            array([3, dtype=int32])
 
         See also:
             _rescale_precision
@@ -676,6 +701,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         Returns:
             Union[int, np.ndarray]: Weight of BaseXPPauli
+        
+        Examples:
+            >>> a = BaseXPPauli(matrix=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64), phase_exp = 12, precision = 8)
+            >>> a.weight()
+            array([5])
 
         See also:
             _weight
@@ -710,6 +740,15 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         Returns:
             np.ndarray: True, if BaseXPPauli is diagonal
 
+        Examples:
+            >>> a = BaseXPPauli(matrix=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64), phase_exp=0, precision=8)
+            >>> a.is_diagonal()
+            array([True])
+
+            >>> b = BaseXPPauli(matrix=np.array([0, 1, 0, 1, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64), phase_exp=12, precision=8)
+            >>> b.is_diagonal()
+            array([False])
+
         See also:
             _is_diagonal
         """
@@ -743,6 +782,14 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         Returns:
             BaseXPPauli: Antisymmetric operator corresponding to BaseXPPauli, if x is 0
+
+        Examples:
+            >>> a = BaseXPPauli(matrix=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], dtype=np.int64), phase_exp=0, precision=8)
+            >>> value = a.antisymmetric_op()
+            >>> value.matrix
+            array([0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], dtype=int64)
+            >>> value._phase_exp
+            array([15])
 
         See also:
             _antisymmetric_op
@@ -790,6 +837,14 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         Returns:
             BaseXPPauli: BaseXPPauli raised to the power n
+
+        Examples:
+            >>> a = BaseXPPauli(matrix=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64), phase_exp=12, precision=8)
+            >>> value = a.power(n=5)
+            >>> value.matrix
+            array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], dtype=int64)
+            >>> value._phase_exp
+            array([8])
 
         See also:
             _power
@@ -854,6 +909,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         Returns:
             np.ndarray: Degree of BaseXPPauli
 
+        Examples:
+        >>> a = BaseXPPauli(matrix=np.array([0, 0, 0, 2, 1, 0], dtype=np.int64), phase_exp=2, precision=4)
+        >>> a.degree()
+        array([4], dtype=int64)
+
         See also:
             _degree
         """
@@ -877,17 +937,21 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         """
 
         gcd = np.gcd(self.z, self.precision)
-        precision_by_gcd = np.floor_divide(self.precision, gcd)
-        lcm = np.atleast_1d(precision_by_gcd)[0]
-        for i in precision_by_gcd:
-            lcm = np.lcm(lcm, i)
+        precision_by_gcd = np.atleast_2d(np.floor_divide(self.precision, gcd))
+        lcm = np.atleast_2d(precision_by_gcd)[:,0]
+        for i,val in enumerate(precision_by_gcd):
+            for j in val:
+                lcm[i] = np.lcm(lcm[i], j)
 
-        square = type(self)(BaseXPPauli.compose(self, self))
+        square = BaseXPPauli.compose(self, self)
+        if type(square) != type(self):
+            square = type(self)(square)
         gcd_square = np.gcd(square.z, square.precision)
-        precision_by_gcd_square = np.floor_divide(square.precision, gcd_square)
-        lcm_square = np.atleast_1d(precision_by_gcd_square)[0]
-        for i in precision_by_gcd_square:
-            lcm_square = np.lcm(lcm_square, i)
+        precision_by_gcd_square = np.atleast_2d(np.floor_divide(square.precision, gcd_square))
+        lcm_square = np.atleast_2d(precision_by_gcd_square)[:,0]
+        for i,val in enumerate(precision_by_gcd_square):
+            for j in val:
+                lcm_square[i] = np.lcm(lcm_square[i], j)
 
         lcm_square = 2 * lcm_square
 

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -86,7 +86,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             precision: Precision of XP operators. Must be an integer greater than or equal to 2.
             order: Set to 'xz' or 'zx'. Defines which side the x and z parts of the input matrix
 
-        Raises: 
+        Raises:
             QiskitError: matrix and phase_exp sizes are not compatible, or if precision is less than 2.
 
         Examples:
@@ -98,7 +98,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         """
 
         if not (isinstance(precision, int) and (precision > 1)):
-            raise QiskitError("Precision of XP operators must be an integer greater than or equal to 2.")
+            raise QiskitError(
+                "Precision of XP operators must be an integer greater than or equal to 2."
+            )
 
         if matrix is None or matrix.size == 0:
             matrix = np.empty(shape=(0, 0), dtype=np.int64)
@@ -311,10 +313,12 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         Raises:
             QiskitError: if number of qubits of other does not match qargs, or
                          if precision of other does not match precision of self.
-       
+
         Examples:
-            >>> a = BaseXPPauli(matrix=np.array([0, 1, 0, 0, 2, 0], dtype=np.int64), phase_exp=6, precision=4)
-            >>> b = BaseXPPauli(matrix=np.array([1, 1, 1, 3, 3, 0], dtype=np.int64), phase_exp=2, precision=4)
+            >>> a = BaseXPPauli(matrix=np.array([0, 1, 0, 0, 2, 0], dtype=np.int64),
+            ... phase_exp=6, precision=4)
+            >>> b = BaseXPPauli(matrix=np.array([1, 1, 1, 3, 3, 0], dtype=np.int64),
+            ... phase_exp=2, precision=4)
             >>> value = BaseXPPauli.compose(a, b)
             >>> value.matrix
             array([[1, 0, 1, 3, 3, 0]], dtype=int64)
@@ -341,7 +345,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             )
 
         if self.precision != other.precision:
-            raise QiskitError("Precision of the two BaseXPPaulis to be multiplied must be the same.")
+            raise QiskitError(
+                "Precision of the two BaseXPPaulis to be multiplied must be the same."
+            )
 
         return self._compose(self, other, qargs=qargs, front=front, inplace=inplace)
 
@@ -569,7 +575,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             BaseXPPauli: Unique vector representation of self
 
         Examples:
-            >>> a = BaseXPPauli(matrix=np.array([0, 3, 1, 6, 4, 3], dtype=np.int64), phase_exp=11, precision=4)
+            >>> a = BaseXPPauli(matrix=np.array([0, 3, 1, 6, 4, 3], dtype=np.int64),
+            ... phase_exp=11, precision=4)
             >>> a = a.unique_vector_rep()
             >>> a.matrix
             np.array([[0, 1, 1, 2, 0, 3]], dtype=int64)
@@ -622,10 +629,12 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             BaseXPPauli: Resultant of rescaling the precision of BaseXPPauli
 
         Raises:
-            QiskitError: If it is not possible to express BaseXPPauli in new_precision 
-        
+            QiskitError: If it is not possible to express BaseXPPauli in new_precision
+
         Examples:
-            >>> a = BaseXPPauli(matrix=np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64), phase_exp=12, precision=8)
+            >>> a = BaseXPPauli(
+            ... matrix=np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64),
+            ... phase_exp=12, precision=8)
             >>> a = a.rescale_precision(new_precision=2)
             >>> a.matrix
             array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]], dtype=int64)
@@ -639,8 +648,15 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         old_precision = self.precision
         if new_precision < old_precision:
             scale_factor = old_precision // new_precision
-        if(((new_precision > old_precision) and (new_precision % old_precision > 0)) or ((new_precision < old_precision) and ((old_precision % new_precision > 0) or (np.sum(np.mod(unique_xp_op._phase_exp, scale_factor)) > 0) or (np.sum(np.mod(unique_xp_op.z, scale_factor)) > 0)))):
+        if (new_precision > old_precision) and (new_precision % old_precision > 0):
             raise QiskitError("XP Operator can not be expressed in new_precision.")
+        if (new_precision < old_precision) and (
+            (old_precision % new_precision > 0)
+            or (np.sum(np.mod(unique_xp_op._phase_exp, scale_factor)) > 0)
+            or (np.sum(np.mod(unique_xp_op.z, scale_factor)) > 0)
+        ):
+            raise QiskitError("XP Operator can not be expressed in new_precision.")
+
         return self._rescale_precision(new_precision)
 
     def _rescale_precision(self, new_precision: int) -> "BaseXPPauli":
@@ -706,9 +722,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         Returns:
             Union[int, np.ndarray]: Weight of BaseXPPauli
-        
+
         Examples:
-            >>> a = BaseXPPauli(matrix=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64), phase_exp = 12, precision = 8)
+            >>> a = BaseXPPauli(
+            ... matrix=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64),
+            ... phase_exp = 12, precision = 8)
             >>> a.weight()
             array([5])
 
@@ -746,11 +764,15 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             np.ndarray: True, if BaseXPPauli is diagonal
 
         Examples:
-            >>> a = BaseXPPauli(matrix=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64), phase_exp=0, precision=8)
+            >>> a = BaseXPPauli(
+            ... matrix=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64),
+            ... phase_exp=0, precision=8)
             >>> a.is_diagonal()
             array([True])
 
-            >>> b = BaseXPPauli(matrix=np.array([0, 1, 0, 1, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64), phase_exp=12, precision=8)
+            >>> b = BaseXPPauli(
+            ... matrix=np.array([0, 1, 0, 1, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64),
+            ... phase_exp=12, precision=8)
             >>> b.is_diagonal()
             array([False])
 
@@ -789,7 +811,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             BaseXPPauli: Antisymmetric operator corresponding to BaseXPPauli, if x is 0
 
         Examples:
-            >>> a = BaseXPPauli(matrix=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], dtype=np.int64), phase_exp=0, precision=8)
+            >>> a = BaseXPPauli(
+            ... matrix=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], dtype=np.int64),
+            ... phase_exp=0, precision=8)
             >>> value = a.antisymmetric_op()
             >>> value.matrix
             array([0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], dtype=int64)
@@ -844,7 +868,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             BaseXPPauli: BaseXPPauli raised to the power n
 
         Examples:
-            >>> a = BaseXPPauli(matrix=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64), phase_exp=12, precision=8)
+            >>> a = BaseXPPauli(
+            ... matrix=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64),
+            ... phase_exp=12, precision=8)
             >>> value = a.power(n=5)
             >>> value.matrix
             array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], dtype=int64)
@@ -914,7 +940,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             np.ndarray: Degree of BaseXPPauli
 
         Examples:
-        >>> a = BaseXPPauli(matrix=np.array([0, 0, 0, 2, 1, 0], dtype=np.int64), phase_exp=2, precision=4)
+        >>> a = BaseXPPauli(matrix=np.array([0, 0, 0, 2, 1, 0], dtype=np.int64),
+        ... phase_exp=2, precision=4)
         >>> a.degree()
         array([4], dtype=int64)
 
@@ -942,18 +969,18 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         gcd = np.gcd(self.z, self.precision)
         precision_by_gcd = np.atleast_2d(np.floor_divide(self.precision, gcd))
-        lcm = np.atleast_2d(precision_by_gcd)[:,0]
-        for i,val in enumerate(precision_by_gcd):
+        lcm = np.atleast_2d(precision_by_gcd)[:, 0]
+        for i, val in enumerate(precision_by_gcd):
             for j in val:
                 lcm[i] = np.lcm(lcm[i], j)
 
         square = BaseXPPauli.compose(self, self)
-        if type(square) != type(self):
+        if not isinstance(square, type(self)):
             square = type(self)(square)
         gcd_square = np.gcd(square.z, square.precision)
         precision_by_gcd_square = np.atleast_2d(np.floor_divide(square.precision, gcd_square))
-        lcm_square = np.atleast_2d(precision_by_gcd_square)[:,0]
-        for i,val in enumerate(precision_by_gcd_square):
+        lcm_square = np.atleast_2d(precision_by_gcd_square)[:, 0]
+        for i, val in enumerate(precision_by_gcd_square):
             for j in val:
                 lcm_square[i] = np.lcm(lcm_square[i], j)
 

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -593,8 +593,6 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         """(TODO improve doc) This is the equivalent of XPDistance function
         from Mark's code. It returns the count of qubits where either z or x
         component is nonzero."""
-        # TODO Since 'distance' has a specific meaning in QECCs, for now, the
-        # name 'weight' has been used for this function.
         return np.sum(np.logical_or(self.x, self.z), axis=-1)
 
     def is_diagonal(self):

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -879,7 +879,6 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         # supposed to calculate inverses as well, that functionality needs to
         # be coded.
 
-        # TODO n = np.atleast_1d(n)
         a = np.mod(n, 2)
 
         x = np.multiply(self.x, a)

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -545,21 +545,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def unique_vector_rep(self) -> "BaseXPPauli":
-        """_summary_
-        Note:
-            This method is adapted from method XPRound from XPFpackage:
-            https://github.com/m-webster/XPFpackage, originally developed by
-            Mark Webster. The original code is licensed under the GNU General
-            Public License v3.0 and Mark Webster has given permission to use
-            the code under the Apache License v2.0.
-
-        See also:
-            _unique_vector_rep
-        """
-        return self._unique_vector_rep()
-
-    def _unique_vector_rep(self) -> "BaseXPPauli":
-        """(TODO improve doc): This method converts the XPPauli operator into unique vector form, ie
+        """Convert the BaseXPPauli operator into unique vector form, ie
         phase_exp in Z modulo 2*precision, x in Z_2, z in Z modulo
         precision.
 
@@ -569,6 +555,29 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            BaseXPPauli: Unique vector representation of self
+
+        See also:
+            _unique_vector_rep
+        """
+        return self._unique_vector_rep()
+
+    def _unique_vector_rep(self) -> "BaseXPPauli":
+        """Convert the BaseXPPauli operator into unique vector form, ie
+        phase_exp in Z modulo 2*precision, x in Z_2, z in Z modulo
+        precision.
+
+        Note:
+            This method is adapted from method XPRound from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+
+        Returns:
+            BaseXPPauli: Unique vector representation of self
         """
         matrix = np.empty(shape=np.shape(self.matrix), dtype=np.int64)
 
@@ -579,23 +588,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BaseXPPauli(matrix, phase_exp, self.precision)
 
     def rescale_precision(self, new_precision: int) -> "BaseXPPauli":
-        """_summary_
-
-        Note:
-            This method is adapted from method XPSetN from XPFpackage:
-            https://github.com/m-webster/XPFpackage, originally developed by
-            Mark Webster. The original code is licensed under the GNU General
-            Public License v3.0 and Mark Webster has given permission to use
-            the code under the Apache License v2.0.
-
-        See also:
-            _rescale_precision
-        """
-        return self._rescale_precision(new_precision)
-
-    def _rescale_precision(self, new_precision: int) -> "BaseXPPauli":
-        """(TODO improve doc): It rescales the generalized symplectic vector components
-        of XPPauli operator to the new precision. Returns None if the
+        """Rescale the generalized symplectic vector components
+        of BaseXPPauli operator to the new precision. Returns None if the
         rescaling is not possible, else returns the rescaled BaseXPPauli object.
 
         Note:
@@ -604,6 +598,38 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Args:
+            new_precision: The target precision in which BaseXPPauli is to be expressed
+
+        Returns:
+            BaseXPPauli: Resultant of rescaling the precision of BaseXPPauli
+
+        Raises:
+            QiskitError: If it is not possible to express BaseXPPauli in new_precision 
+
+        See also:
+            _rescale_precision
+        """
+        return self._rescale_precision(new_precision)
+
+    def _rescale_precision(self, new_precision: int) -> "BaseXPPauli":
+        """Rescale the generalized symplectic vector components
+        of BaseXPPauli operator to the new precision. Returns None if the
+        rescaling is not possible, else returns the rescaled BaseXPPauli object.
+
+        Note:
+            This method is adapted from method XPSetN from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+
+        Args:
+            new_precision: The target precision in which BaseXPPauli is to be expressed
+
+        Returns:
+            BaseXPPauli: Resultant of rescaling the precision of BaseXPPauli
 
         See also:
             unique_vector_rep
@@ -639,7 +665,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BaseXPPauli(matrix, phase_exp, new_precision)
 
     def weight(self) -> Union[int, np.ndarray]:
-        """_summary_
+        """Return the weight, i.e. count of qubits where either z or x component is nonzero.
 
         Note:
             This method is adapted from method XPDistance from XPFpackage:
@@ -647,6 +673,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            Union[int, np.ndarray]: Weight of BaseXPPauli
 
         See also:
             _weight
@@ -654,8 +683,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self._weight()
 
     def _weight(self) -> Union[int, np.ndarray]:
-        """(TODO improve doc) This method returns the count of qubits where either z or x
-        component is nonzero.
+        """Return the weight, i.e. count of qubits where either z or x component is nonzero.
 
         Note:
             This method is adapted from method XPDistance from XPFpackage:
@@ -663,11 +691,14 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            Union[int, np.ndarray]: Weight of BaseXPPauli
         """
         return np.sum(np.logical_or(self.x, self.z), axis=-1)
 
     def is_diagonal(self) -> np.ndarray:
-        """_summary_
+        """Return True if the XP operator is diagonal.
 
         Note:
             This method is adapted from method XPisDiag from XPFpackage:
@@ -675,6 +706,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            np.ndarray: True, if BaseXPPauli is diagonal
 
         See also:
             _is_diagonal
@@ -682,7 +716,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self._is_diagonal()
 
     def _is_diagonal(self) -> np.ndarray:
-        """(TODO improve doc) Returns True if the XP operator is diagonal.
+        """Return True if the XP operator is diagonal.
 
         Note:
             This method is adapted from method XPisDiag from XPFpackage:
@@ -690,11 +724,15 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            np.ndarray: True, if BaseXPPauli is diagonal
         """
         return np.where(np.sum(self.x, axis=-1) == 0, True, False)
 
     def antisymmetric_op(self) -> "BaseXPPauli":
-        """_summary_
+        """Return the antisymmetric operator corresponding to the
+        z component of XP operator, only if x component is 0.
 
         Note:
             This method is adapted from method XPD from XPFpackage:
@@ -703,13 +741,16 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
 
+        Returns:
+            BaseXPPauli: Antisymmetric operator corresponding to BaseXPPauli, if x is 0
+
         See also:
             _antisymmetric_op
         """
         return self._antisymmetric_op()
 
     def _antisymmetric_op(self) -> "BaseXPPauli":
-        """(TODO improve doc) This method returns the antisymmetric operator corresponding to the
+        """Return the antisymmetric operator corresponding to the
         z component of XP operator, only if x component is 0, else it returns
         None.
 
@@ -719,6 +760,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            BaseXPPauli: Antisymmetric operator corresponding to BaseXPPauli, if x is 0
         """
 
         if np.any(self.x):
@@ -732,7 +776,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BaseXPPauli(matrix=matrix, phase_exp=phase_exp, precision=self.precision)
 
     def power(self, n: int) -> "BaseXPPauli":
-        """_summary_
+        """Return the XP operator of specified precision raised to the power n.
 
         Note:
             This method is adapted from method XPPower from XPFpackage:
@@ -740,6 +784,12 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Args:
+            n: The power to which BaseXPPauli is to be raised
+
+        Returns:
+            BaseXPPauli: BaseXPPauli raised to the power n
 
         See also:
             _power
@@ -747,8 +797,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self._power(n)
 
     def _power(self, n: int) -> "BaseXPPauli":
-        """(TODO improve doc) This method returns the XP operator of specified precision raised
-        to the power n.
+        """Return the XP operator of specified precision raised to the power n.
 
         Note:
             This method is adapted from method XPPower from XPFpackage:
@@ -756,6 +805,12 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Args:
+            n: The power to which BaseXPPauli is to be raised
+
+        Returns:
+            BaseXPPauli: BaseXPPauli raised to the power n
 
         See also:
             _unique_vector_rep
@@ -787,7 +842,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return product._unique_vector_rep()
 
     def degree(self) -> np.ndarray:
-        """_summary_
+        """Return the degree of XP operator.
 
         Note:
             This method is adapted from method XPDegree from XPFpackage:
@@ -795,6 +850,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            np.ndarray: Degree of BaseXPPauli
 
         See also:
             _degree
@@ -802,7 +860,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self._degree()
 
     def _degree(self) -> np.ndarray:
-        """(TODO improve doc) This method returns the degree of XP operator.
+        """Return the degree of XP operator.
 
         Note:
             This method is adapted from method XPDegree from XPFpackage:
@@ -810,6 +868,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            np.ndarray: Degree of BaseXPPauli
 
         See also:
             is_diagonal

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -309,7 +309,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             BaseXPPauli : Compositon of self and other
 
         Raises:
-            QiskitError: if number of qubits of other does not match qargs.
+            QiskitError: if number of qubits of other does not match qargs, or
+                         if precision of other does not match precision of self.
 
         See also:
             _compose
@@ -329,6 +330,9 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
                 "Incompatible BaseXPPaulis. Second list must "
                 "either have 1 or the same number of XPPaulis."
             )
+
+        if self.precision != other.precision:
+            raise QiskitError("Precision of the two BaseXPPaulis to be multiplied must be the same.")
 
         return self._compose(self, other, qargs=qargs, front=front, inplace=inplace)
 
@@ -362,10 +366,6 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         See also:
             unique_vector_rep, _unique_vector_rep
         """
-
-        assert a.precision == b.precision, QiskitError(
-            "Precision of the two BaseXPPaulis to be multiplied must be the same."
-        )
 
         if qargs is not None:
             qargs = list(qargs) + [item + a.num_qubits for item in qargs]

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -465,6 +465,17 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         return BaseXPPauli(matrix, phase_exp, new_precision)
 
+    def weight(self):
+        return self._weight()
+
+    def _weight(self):
+        """(TODO improve doc) This is the equivalent of XPDistance function
+        from Mark's code. It returns the count of qubits where either z or x
+        component is nonzero."""
+        # TODO Since 'distance' has a specific meaning in QECCs, for now, the
+        # name 'weight' has been used for this function.
+        return np.sum(np.logical_and(self.x, self.z), axis=-1)
+
 
 # ---------------------------------------------------------------------
 # Evolution by Clifford gates

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -91,7 +91,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Pauli, PauliList
         """
 
-        assert isinstance(precision, (int, np.ndarray)) and (np.all(precision > 1)), QiskitError(
+        assert isinstance(precision, int) and (np.all(precision > 1)), QiskitError(
             "Precision of XP operators must be an integer greater than or equal to 2."
         )
 

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -633,7 +633,35 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         return product._unique_vector_rep()
 
+    
+    def degree(self):
+        return self._degree()
 
+    def _degree(self):
+        """(TODO improve doc) This is the equivalent of XPDegree from Mark's
+        code. It returns the degree of XP operator."""
+
+        gcd = np.gcd(self.z, self.precision)
+        precision_by_gcd = np.floor_divide(self.precision, gcd)
+        lcm = np.atleast_1d(precision_by_gcd)[0]
+        for i in precision_by_gcd:
+            lcm = np.lcm(lcm, i)
+
+        square = type(self)(BaseXPPauli.compose(self, self))
+        gcd_square = np.gcd(square.z, square.precision)
+        precision_by_gcd_square = np.floor_divide(square.precision, gcd_square)
+        lcm_square = np.atleast_1d(precision_by_gcd_square)[0]
+        for i in precision_by_gcd_square:
+            lcm_square = np.lcm(lcm_square, i)
+
+        lcm_square = 2 * lcm_square
+
+        # TODO it can be explored (maybe with Mark) if the algorithm used when
+        # the XP operator is non-diagonal (which involves squaring) gives the
+        # correct output for diagonal XP operators as well (naively that seems
+        # to be true). If that is the case, then checking np.where and
+        # is_diagonal can be removed and the code can be optimized a bit.
+        return np.where(self.is_diagonal(), lcm, lcm_square) 
 
 
 # ---------------------------------------------------------------------

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -53,7 +53,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         self,
         matrix: Union[np.ndarray, None] = None,
         phase_exp: Union[None, np.ndarray, np.integer] = None,
-        precision: int = None,
+        precision: Union[int, np.ndarray] = None,
         order: str = "xz",
     ) -> None:
         # TODO: Need to update this docstring once the representation to be
@@ -90,7 +90,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         See Also:
             Pauli, PauliList
         """
-        assert (type(precision) == int) and (precision > 1), QiskitError(
+
+        assert ((type(precision) == int) or (type(precision) == np.ndarray)) and (np.all(precision > 1)), QiskitError(
             "Precision of XP operators must be an integer greater than or equal to 2."
         )
 

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -108,6 +108,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         self.matrix = matrix
         self.precision = precision
+        # TODO should _num_paulis be renamed to _num_xppaulis in this and derived classes?
         self._num_paulis = self.matrix.shape[0]
         if phase_exp is None:
             self._phase_exp = np.zeros(shape=(self.matrix.shape[0],), dtype=np.int64)

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -11,6 +11,11 @@
 # that they have been altered from the originals.
 
 # Part of the QEC framework
+#
+# This code is based on the paper: "The XP Stabiliser Formalism: a
+# Generalisation of the Pauli Stabiliser Formalism with Arbitrary Phases", Mark
+# A. Webster, Benjamin J. Brown, and Stephen D. Bartlett. Quantum 6, 815
+# (2022).
 """Module for base XP pauli"""
 
 import numbers
@@ -287,6 +292,11 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         Note:
             This method does compose coordinate wise (which is different from the PauliTable compose
             which should be corrected at some point).
+            This method is adapted from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
 
         Args:
             other: BaseXPPauli
@@ -335,6 +345,13 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             qargs (Optional[list], optional): _description_. Defaults to None.
             front (bool, optional): _description_. Defaults to False.
             inplace (bool, optional): _description_. Defaults to False.
+
+        Note:
+            This method is adapted from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
 
         Returns:
             BaseXPPauli: _description_
@@ -522,14 +539,29 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     # ---------------------------------------------------------------------
 
     def unique_vector_rep(self) -> "BaseXPPauli":
-        """_summary_"""
+        """_summary_
+        Note:
+            This method is adapted from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return self._unique_vector_rep()
 
     def _unique_vector_rep(self) -> "BaseXPPauli":
         """(TODO improve doc): This is the equivalent of XPRound from Mark's
         code. It converts the XPPauli operator into unique vector form, ie
         phase_exp in Z modulo 2*precision, x in Z_2, z in Z modulo
-        precision."""
+        precision.
+
+        Note:
+            This method is adapted from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         matrix = np.empty(shape=np.shape(self.matrix), dtype=np.int64)
 
         phase_exp = np.mod(self._phase_exp, 2 * self.precision)
@@ -546,7 +578,15 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         """(TODO improve doc): This is the equivalent of XPSetNsingle from
         Mark's code. It rescales the generalized symplectic vector components
         of XPPauli operator to the new precision. Returns None if the
-        rescaling is not possible, else returns the rescaled BaseXPPauli object."""
+        rescaling is not possible, else returns the rescaled BaseXPPauli object.
+
+        Note:
+            This method is adapted from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
 
         # TODO Currently, if any operator in an XPPauliList can not be
         # rescaled, this function will return None.

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -474,8 +474,15 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         component is nonzero."""
         # TODO Since 'distance' has a specific meaning in QECCs, for now, the
         # name 'weight' has been used for this function.
-        return np.sum(np.logical_and(self.x, self.z), axis=-1)
+        return np.sum(np.logical_or(self.x, self.z), axis=-1)
 
+    def is_diagonal(self):
+        return self._is_diagonal()
+
+    def _is_diagonal(self):
+        """(TODO improve doc) This is the equivalent of XPisDiag function from
+        Mark's code. Returns True if the XP operator is diagonal."""
+        return np.where(np.sum(self.x, axis=-1)==0, True, False)
 
 # ---------------------------------------------------------------------
 # Evolution by Clifford gates

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -605,9 +605,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BaseXPPauli(matrix, phase_exp, self.precision)
 
     def rescale_precision(self, new_precision: int) -> "BaseXPPauli":
-        """Rescale the generalized symplectic vector components
-        of BaseXPPauli operator to the new precision. Returns None if the
-        rescaling is not possible, else returns the rescaled BaseXPPauli object.
+        """Rescale the generalized symplectic vector components of BaseXPPauli
+        operator to the new precision.
 
         Note:
             This method is adapted from method XPSetN from XPFpackage:
@@ -636,6 +635,12 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         See also:
             _rescale_precision
         """
+        unique_xp_op = self.unique_vector_rep()
+        old_precision = self.precision
+        if new_precision < old_precision:
+            scale_factor = old_precision // new_precision
+        if(((new_precision > old_precision) and (new_precision % old_precision > 0)) or ((new_precision < old_precision) and ((old_precision % new_precision > 0) or (np.sum(np.mod(unique_xp_op._phase_exp, scale_factor)) > 0) or (np.sum(np.mod(unique_xp_op.z, scale_factor)) > 0)))):
+            raise QiskitError("XP Operator can not be expressed in new_precision.")
         return self._rescale_precision(new_precision)
 
     def _rescale_precision(self, new_precision: int) -> "BaseXPPauli":

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -109,8 +109,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         self.matrix = matrix
         self.precision = precision
-        # TODO should _num_paulis be renamed to _num_xppaulis in this and derived classes?
-        self._num_paulis = self.matrix.shape[0]
+        self._num_xppaulis = self.matrix.shape[0]
         if phase_exp is None:
             self._phase_exp = np.zeros(shape=(self.matrix.shape[0],), dtype=np.int64)
         else:
@@ -312,7 +311,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
                 f"Number of qubits of the other {type(self).__name__} does not match qargs."
             )
 
-        if other._num_paulis not in [1, self._num_paulis]:
+        if other._num_xppaulis not in [1, self._num_xppaulis]:
             raise QiskitError(
                 "Incompatible BaseXPPaulis. Second list must "
                 "either have 1 or the same number of XPPaulis."

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -292,7 +292,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         Note:
             This method does compose coordinate wise (which is different from the PauliTable compose
             which should be corrected at some point).
-            This method is adapted from XPFpackage:
+            This method is adapted from method XPMul from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
@@ -347,7 +347,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             inplace (bool, optional): _description_. Defaults to False.
 
         Note:
-            This method is adapted from XPFpackage:
+            This method is adapted from method XPMul from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
@@ -541,7 +541,7 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
     def unique_vector_rep(self) -> "BaseXPPauli":
         """_summary_
         Note:
-            This method is adapted from XPFpackage:
+            This method is adapted from method XPRound from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
@@ -550,13 +550,12 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self._unique_vector_rep()
 
     def _unique_vector_rep(self) -> "BaseXPPauli":
-        """(TODO improve doc): This is the equivalent of XPRound from Mark's
-        code. It converts the XPPauli operator into unique vector form, ie
+        """(TODO improve doc): This method converts the XPPauli operator into unique vector form, ie
         phase_exp in Z modulo 2*precision, x in Z_2, z in Z modulo
         precision.
 
         Note:
-            This method is adapted from XPFpackage:
+            This method is adapted from method XPRound from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
@@ -571,17 +570,24 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BaseXPPauli(matrix, phase_exp, self.precision)
 
     def rescale_precision(self, new_precision: int) -> "BaseXPPauli":
-        """_summary_"""
+        """_summary_
+
+        Note:
+            This method is adapted from method XPSetN from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return self._rescale_precision(new_precision)
 
     def _rescale_precision(self, new_precision: int) -> "BaseXPPauli":
-        """(TODO improve doc): This is the equivalent of XPSetNsingle from
-        Mark's code. It rescales the generalized symplectic vector components
+        """(TODO improve doc): It rescales the generalized symplectic vector components
         of XPPauli operator to the new precision. Returns None if the
         rescaling is not possible, else returns the rescaled BaseXPPauli object.
 
         Note:
-            This method is adapted from XPFpackage:
+            This method is adapted from method XPSetN from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
@@ -618,33 +624,78 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BaseXPPauli(matrix, phase_exp, new_precision)
 
     def weight(self) -> Union[int, np.ndarray]:
-        """_summary_"""
+        """_summary_
+
+        Note:
+            This method is adapted from method XPDistance from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return self._weight()
 
     def _weight(self) -> Union[int, np.ndarray]:
-        """(TODO improve doc) This is the equivalent of XPDistance function
-        from Mark's code. It returns the count of qubits where either z or x
-        component is nonzero."""
+        """(TODO improve doc) This method returns the count of qubits where either z or x
+        component is nonzero.
+
+        Note:
+            This method is adapted from method XPDistance from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return np.sum(np.logical_or(self.x, self.z), axis=-1)
 
     def is_diagonal(self) -> np.ndarray:
-        """_summary_"""
+        """_summary_
+
+        Note:
+            This method is adapted from method XPisDiag from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return self._is_diagonal()
 
     def _is_diagonal(self) -> np.ndarray:
-        """(TODO improve doc) This is the equivalent of XPisDiag function from
-        Mark's code. Returns True if the XP operator is diagonal."""
+        """(TODO improve doc) Returns True if the XP operator is diagonal.
+
+        Note:
+            This method is adapted from method XPisDiag from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return np.where(np.sum(self.x, axis=-1) == 0, True, False)
 
     def antisymmetric_op(self) -> "BaseXPPauli":
-        """_summary_"""
+        """_summary_
+
+        Note:
+            This method is adapted from method XPD from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return self._antisymmetric_op()
 
     def _antisymmetric_op(self) -> "BaseXPPauli":
-        """(TODO improve doc) This is the equivalent of XPD function from
-        Mark's code. It returns the antisymmetric operator corresponding to the
+        """(TODO improve doc) This method returns the antisymmetric operator corresponding to the
         z component of XP operator, only if x component is 0, else it returns
-        None."""
+        None.
+
+        Note:
+            This method is adapted from method XPD from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
 
         if np.any(self.x):
             # TODO should there be an assertion here?
@@ -657,13 +708,28 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return BaseXPPauli(matrix=matrix, phase_exp=phase_exp, precision=self.precision)
 
     def power(self, n: int) -> "BaseXPPauli":
-        """_summary_"""
+        """_summary_
+
+        Note:
+            This method is adapted from method XPPower from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return self._power(n)
 
     def _power(self, n: int) -> "BaseXPPauli":
-        """(TODO improve doc) This is te equivalent of XPPower function from
-        Mark's code. It returns the XP operator of specified precision raised
-        to the power n."""
+        """(TODO improve doc) This method returns the XP operator of specified precision raised
+        to the power n.
+
+        Note:
+            This method is adapted from method XPPower from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         # TODO at present, this function only handles positive powers. If it is
         # supposed to calculate inverses as well, that functionality needs to
         # be coded.
@@ -691,12 +757,27 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return product._unique_vector_rep()
 
     def degree(self) -> np.ndarray:
-        """_summary_"""
+        """_summary_
+
+        Note:
+            This method is adapted from method XPDegree from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return self._degree()
 
     def _degree(self) -> np.ndarray:
-        """(TODO improve doc) This is the equivalent of XPDegree from Mark's
-        code. It returns the degree of XP operator."""
+        """(TODO improve doc) This method returns the degree of XP operator.
+
+        Note:
+            This method is adapted from method XPDegree from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
 
         gcd = np.gcd(self.z, self.precision)
         precision_by_gcd = np.floor_divide(self.precision, gcd)

--- a/qiskit_qec/operators/base_xp_pauli.py
+++ b/qiskit_qec/operators/base_xp_pauli.py
@@ -86,7 +86,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             precision: Precision of XP operators. Must be an integer greater than or equal to 2.
             order: Set to 'xz' or 'zx'. Defines which side the x and z parts of the input matrix
 
-        Raises: QiskitError: matrix and phase_exp sizes are not compatible
+        Raises: 
+            QiskitError: matrix and phase_exp sizes are not compatible, or if precision is less than 2.
 
         Examples:
             >>> matrix = numpy.array([[1,1,0,0],[0,1,0,1]])
@@ -96,9 +97,8 @@ class BaseXPPauli(BaseOperator, AdjointMixin, MultiplyMixin):
             Pauli, PauliList
         """
 
-        assert isinstance(precision, int) and (np.all(precision > 1)), QiskitError(
-            "Precision of XP operators must be an integer greater than or equal to 2."
-        )
+        if not (isinstance(precision, int) and (precision > 1)):
+            raise QiskitError("Precision of XP operators must be an integer greater than or equal to 2.")
 
         if matrix is None or matrix.size == 0:
             matrix = np.empty(shape=(0, 0), dtype=np.int64)

--- a/qiskit_qec/operators/pauli_list.py
+++ b/qiskit_qec/operators/pauli_list.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 # Part of the QEC framework
-"""Module fo Pauli List"""
+"""Module for Pauli List"""
 import numbers
 from collections import defaultdict
 from typing import Iterable, List, Tuple, Union

--- a/qiskit_qec/operators/pauli_list.py
+++ b/qiskit_qec/operators/pauli_list.py
@@ -10,6 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 # Part of the QEC framework
+#
+# This code is based on the paper: "The XP Stabiliser Formalism: a
+# Generalisation of the Pauli Stabiliser Formalism with Arbitrary Phases", Mark
+# A. Webster, Benjamin J. Brown, and Stephen D. Bartlett. Quantum 6, 815
+# (2022).
 """Module for Pauli List"""
 import numbers
 from collections import defaultdict

--- a/qiskit_qec/operators/random.py
+++ b/qiskit_qec/operators/random.py
@@ -22,6 +22,7 @@ from qiskit.quantum_info.operators.symplectic.stabilizer_table import Stabilizer
 
 from qiskit_qec.operators.pauli import Pauli
 from qiskit_qec.operators.pauli_list import PauliList
+from qiskit_qec.operators.xp_pauli import XPPauli
 
 
 def random_pauli(num_qubits, group_phase=False, seed=None):

--- a/qiskit_qec/operators/random.py
+++ b/qiskit_qec/operators/random.py
@@ -13,6 +13,7 @@
 Random symplectic operator functions
 """
 
+from typing import Union
 import numpy as np
 from numpy.random import default_rng
 
@@ -197,7 +198,11 @@ def random_clifford(num_qubits, seed=None):
     return Clifford(StabilizerTable(table, phase))
 
 
-def random_xppauli(num_qubits, precision=None, seed=None):
+def random_xppauli(
+    num_qubits: int,
+    precision: int = None,
+    seed: Union[int, np.random.Generator, None] = None,
+) -> XPPauli:
     """Return a random XPPauli.
 
     Args:

--- a/qiskit_qec/operators/random.py
+++ b/qiskit_qec/operators/random.py
@@ -205,6 +205,13 @@ def random_xppauli(
 ) -> XPPauli:
     """Return a random XPPauli.
 
+    Note:
+        This method is adapted from XPFpackage:
+        https://github.com/m-webster/XPFpackage, originally developed by
+        Mark Webster. The original code is licensed under the GNU General
+        Public License v3.0 and Mark Webster has given permission to use
+        the code under the Apache License v2.0.
+
     Args:
         num_qubits (int): the number of qubits.
         precision (int): Precision of XP operators. Must be an integer
@@ -225,6 +232,7 @@ def random_xppauli(
     x = rng.integers(2, size=num_qubits, dtype=bool)
     # TODO: Need to decide whether we will add an argument group_phase in
     # analogy with random_pauli. If yes, its implementation goes here.
+
     # Mark's code randomizes phase modulo 2*precision.
     phase = rng.integers(2 * precision, dtype=np.int64)
     xppauli = XPPauli((z, x, phase))

--- a/qiskit_qec/operators/random.py
+++ b/qiskit_qec/operators/random.py
@@ -219,6 +219,9 @@ def random_xppauli(
         seed (int or np.random.Generator): Optional. Set a fixed seed or
                                            generator for RNG.
 
+    Examples:
+        >>> value = random_xppauli(num_qubits=3, precision=8)
+
     Returns:
         XPPauli: a random XPPauli
     """
@@ -235,7 +238,7 @@ def random_xppauli(
 
     # Mark's code randomizes phase modulo 2*precision.
     phase = rng.integers(2 * precision, dtype=np.int64)
-    xppauli = XPPauli((z, x, phase))
+    xppauli = XPPauli(data=np.concatenate((z, x)), phase_exp=phase, precision=precision)
     return xppauli
 
 

--- a/qiskit_qec/operators/random.py
+++ b/qiskit_qec/operators/random.py
@@ -196,6 +196,38 @@ def random_clifford(num_qubits, seed=None):
     return Clifford(StabilizerTable(table, phase))
 
 
+def random_xppauli(num_qubits, precision=None, seed=None):
+    """Return a random XPPauli.
+
+    Args:
+        num_qubits (int): the number of qubits.
+        precision (int): Precision of XP operators. Must be an integer
+                         greater than or equal to 2.
+        seed (int or np.random.Generator): Optional. Set a fixed seed or
+                                           generator for RNG.
+
+    Returns:
+        XPPauli: a random XPPauli
+    """
+    if seed is None:
+        rng = np.random.default_rng()
+    elif isinstance(seed, np.random.Generator):
+        rng = seed
+    else:
+        rng = default_rng(seed)
+    z = rng.integers(precision, size=num_qubits, dtype=np.int64)
+    x = rng.integers(2, size=num_qubits, dtype=bool)
+    # TODO: Need to decide whether we will add an argument group_phase in
+    # analogy with random_pauli. If yes, its implementation goes here.
+    # Mark's code randomizes phase modulo 2*precision.
+    phase = rng.integers(2 * precision, dtype=np.int64)
+    xppauli = XPPauli((z, x, phase))
+    return xppauli
+
+
+# TODO: def random_xppauli_list():
+
+
 def _sample_qmallows(n, rng=None):
     """Sample from the quantum Mallows distribution"""
 

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -174,6 +174,15 @@ class XPPauli(BaseXPPauli):
             multiplication and is equivalent to the :meth:`dot` method
             ``A.dot(B) == A.compose(B, front=True)``.
 
+        Examples:
+            >>> a = XPPauli(data=np.array([0, 1, 0, 0, 2, 0], dtype=np.int64), phase_exp=6, precision=4)
+            >>> b = XPPauli(data=np.array([1, 1, 1, 3, 3, 0], dtype=np.int64), phase_exp=2, precision=4)
+            >>> value = XPPauli.compose(a, b)
+            >>> value.matrix
+            array([[1, 0, 1, 3, 3, 0]], dtype=int64)
+            >>> value._phase_exp
+            array([6])
+
         See also:
             _compose
         """
@@ -203,6 +212,14 @@ class XPPauli(BaseXPPauli):
         Returns:
             XPPauli: Unique vector representation of self
 
+        Examples:
+            >>> a = XPPauli(matrix=np.array([0, 3, 1, 6, 4, 3], dtype=np.int64), phase_exp=11, precision=4)
+            >>> a = a.unique_vector_rep()
+            >>> a.matrix
+            np.array([[0, 1, 1, 2, 0, 3]], dtype=int64)
+            >>> a._phase_exp
+            array([3], dtype=int32)
+
         See also:
             _unique_vector_rep
         """
@@ -228,6 +245,14 @@ class XPPauli(BaseXPPauli):
         Raises:
             QiskitError: If it is not possible to express XPPauli in new_precision 
 
+        Examples:
+            >>> a = XPPauli(data=np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64), phase_exp=12, precision=8)
+            >>> a = a.rescale_precision(new_precision=2)
+            >>> a.matrix
+            array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]], dtype=int64)
+            >>> a._phase_exp
+            array([3, dtype=int32])
+
         See also:
             _rescale_precision
         """
@@ -246,6 +271,14 @@ class XPPauli(BaseXPPauli):
 
         Returns:
             XPPauli: Antisymmetric operator corresponding to XPPauli, if x is 0
+
+        Examples:
+            >>> a = XPPauli(data=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], dtype=np.int64), phase_exp=0, precision=8)
+            >>> value = a.antisymmetric_op()
+            >>> value.matrix
+            array([0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], dtype=int64)
+            >>> value._phase_exp
+            array([15])
 
         See also:
             _antisymmetric_op
@@ -267,6 +300,14 @@ class XPPauli(BaseXPPauli):
 
         Returns:
             XPPauli: XPPauli raised to the power n
+
+        Examples:
+            >>> a = XPPauli(data=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64), phase_exp=12, precision=8)
+            >>> value = a.power(n=5)
+            >>> value.matrix
+            array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], dtype=int64)
+            >>> value._phase_exp
+            array([8])
 
         See also:
             _power

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -172,6 +172,9 @@ class XPPauli(BaseXPPauli):
             Setting the ``front=True`` kwarg changes this to `right` matrix
             multiplication and is equivalent to the :meth:`dot` method
             ``A.dot(B) == A.compose(B, front=True)``.
+
+        See also:
+            _compose
         """
         if qargs is None:
             qargs = getattr(other, "qargs", None)
@@ -189,6 +192,9 @@ class XPPauli(BaseXPPauli):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _unique_vector_rep
         """
         return XPPauli(super().unique_vector_rep())
 
@@ -200,6 +206,9 @@ class XPPauli(BaseXPPauli):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _rescale_precision
         """
         return XPPauli(super().rescale_precision(new_precision))
 
@@ -211,6 +220,9 @@ class XPPauli(BaseXPPauli):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _antisymmetric_op
         """
         return XPPauli(super().antisymmetric_op())
 
@@ -222,6 +234,9 @@ class XPPauli(BaseXPPauli):
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        See also:
+            _power
         """
         return XPPauli(super().power(n))
 

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -161,7 +161,8 @@ class XPPauli(BaseXPPauli):
 
         Raises:
             QiskitError: if other cannot be converted to an operator, or has
-                         incompatible dimensions for specified subsystems.
+                         incompatible dimensions for specified subsystems, or
+                         if precision of other does not match precision of self.
 
         .. note::
             Composition (``&``) by default is defined as `left` matrix multiplication for
@@ -180,6 +181,9 @@ class XPPauli(BaseXPPauli):
             qargs = getattr(other, "qargs", None)
         if not isinstance(other, XPPauli):
             other = XPPauli(other)
+        if self.precision != other.precision:
+            raise QiskitError("Precision of the two XPPaulis to be multiplied must be the same.")
+
         return XPPauli(super().compose(other, qargs=qargs, front=front, inplace=inplace))
 
     # ---------------------------------------------------------------------

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -213,7 +213,8 @@ class XPPauli(BaseXPPauli):
             XPPauli: Unique vector representation of self
 
         Examples:
-            >>> a = XPPauli(matrix=np.array([0, 3, 1, 6, 4, 3], dtype=np.int64), phase_exp=11, precision=4)
+            >>> a = XPPauli(matrix=np.array([0, 3, 1, 6, 4, 3], dtype=np.int64),
+            ... phase_exp=11, precision=4)
             >>> a = a.unique_vector_rep()
             >>> a.matrix
             np.array([[0, 1, 1, 2, 0, 3]], dtype=int64)
@@ -225,7 +226,7 @@ class XPPauli(BaseXPPauli):
         """
         return XPPauli(super().unique_vector_rep())
 
-    def rescale_precision(self, new_precision) -> "XPPauli":
+    def rescale_precision(self, new_precision: int) -> "XPPauli":
         """Rescale the generalized symplectic vector components
         of XPPauli operator to the new precision. Returns the rescaled XPPauli object.
 
@@ -243,10 +244,12 @@ class XPPauli(BaseXPPauli):
             XPPauli: Resultant of rescaling the precision of XPPauli
 
         Raises:
-            QiskitError: If it is not possible to express XPPauli in new_precision 
+            QiskitError: If it is not possible to express XPPauli in new_precision
 
         Examples:
-            >>> a = XPPauli(data=np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64), phase_exp=12, precision=8)
+            >>> a = XPPauli(
+            ... data=np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64),
+            ... phase_exp=12, precision=8)
             >>> a = a.rescale_precision(new_precision=2)
             >>> a.matrix
             array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]], dtype=int64)
@@ -273,7 +276,9 @@ class XPPauli(BaseXPPauli):
             XPPauli: Antisymmetric operator corresponding to XPPauli, if x is 0
 
         Examples:
-            >>> a = XPPauli(data=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], dtype=np.int64), phase_exp=0, precision=8)
+            >>> a = XPPauli(
+            ... data=np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], dtype=np.int64),
+            ... phase_exp=0, precision=8)
             >>> value = a.antisymmetric_op()
             >>> value.matrix
             array([0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], dtype=int64)
@@ -302,7 +307,9 @@ class XPPauli(BaseXPPauli):
             XPPauli: XPPauli raised to the power n
 
         Examples:
-            >>> a = XPPauli(data=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64), phase_exp=12, precision=8)
+            >>> a = XPPauli(
+            ... data=np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64),
+            ... phase_exp=12, precision=8)
             >>> value = a.power(n=5)
             >>> value.matrix
             array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], dtype=int64)

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -192,5 +192,8 @@ class XPPauli(BaseXPPauli):
     def power(self, n):
         return XPPauli(super().power(n))
 
+    def degree(self):
+        return super().degree()
+
 # Update docstrings for API docs
 generate_apidocs(XPPauli)

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -68,7 +68,8 @@ class XPPauli(BaseXPPauli):
             raise QiskitError("Input is not a single XPPauli")
 
         super().__init__(matrix, phase_exp, precision)
-        self.vlist = self.matrix[0].tolist()
+        # TODO check if this is needed
+        # self.vlist = self.matrix[0].tolist()
 
     # ---------------------------------------------------------------------
     # Property Methods
@@ -126,6 +127,52 @@ class XPPauli(BaseXPPauli):
     @z.setter
     def z(self, val):
         self.matrix[:, self.num_qubits :][0] = val
+
+    # ---------------------------------------------------------------------
+    # BaseOperator methods
+    # ---------------------------------------------------------------------
+
+    def compose(
+        self,
+        other: Union["XPPauli", BaseXPPauli],
+        qargs: Optional[List[int]] = None,
+        front: bool = False,
+        inplace: bool = False,
+    ) -> "XPPauli":
+        """Return the operator composition with another XPPauli.
+
+        Args:
+            other (XPPauli): a XPPauli object.
+            qargs (list or None): Optional, qubits to apply dot product
+                                  on (default: None).
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
+            inplace (bool): If True update in-place (default: False).
+
+        Returns:
+            XPPauli: The composed XPPauli.
+
+        Raises:
+            QiskitError: if other cannot be converted to an operator, or has
+                         incompatible dimensions for specified subsystems.
+
+        .. note::
+            Composition (``&``) by default is defined as `left` matrix multiplication for
+            matrix operators, while :meth:`dot` is defined as `right` matrix
+            multiplication. That is that ``A & B == A.compose(B)`` is equivalent to
+            ``B.dot(A)`` when ``A`` and ``B`` are of the same type.
+
+            Setting the ``front=True`` kwarg changes this to `right` matrix
+            multiplication and is equivalent to the :meth:`dot` method
+            ``A.dot(B) == A.compose(B, front=True)``.
+        """
+        if qargs is None:
+            qargs = getattr(other, "qargs", None)
+        if not isinstance(other, XPPauli):
+            other = XPPauli(other)
+        return XPPauli(super().compose(other, qargs=qargs, front=front, inplace=inplace))
+
+    # ---------------------------------------------------------------------
 
     def unique_vector_rep(self):
         return XPPauli(super().unique_vector_rep())

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -189,13 +189,19 @@ class XPPauli(BaseXPPauli):
     # ---------------------------------------------------------------------
 
     def unique_vector_rep(self) -> "XPPauli":
-        """
+        """Convert the XPPauli operator into unique vector form, ie
+        phase_exp in Z modulo 2*precision, x in Z_2, z in Z modulo
+        precision.
+
         Note:
-            This method is adapted from the method XPRound from XPFpackage:
+            This method is adapted from method XPRound from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Returns:
+            XPPauli: Unique vector representation of self
 
         See also:
             _unique_vector_rep
@@ -203,13 +209,24 @@ class XPPauli(BaseXPPauli):
         return XPPauli(super().unique_vector_rep())
 
     def rescale_precision(self, new_precision) -> "XPPauli":
-        """
+        """Rescale the generalized symplectic vector components
+        of XPPauli operator to the new precision. Returns the rescaled XPPauli object.
+
         Note:
-            This method is adapted from the method XPSetN from XPFpackage:
+            This method is adapted from method XPSetN from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Args:
+            new_precision: The target precision in which XPPauli is to be expressed
+
+        Returns:
+            XPPauli: Resultant of rescaling the precision of XPPauli
+
+        Raises:
+            QiskitError: If it is not possible to express XPPauli in new_precision 
 
         See also:
             _rescale_precision
@@ -217,7 +234,9 @@ class XPPauli(BaseXPPauli):
         return XPPauli(super().rescale_precision(new_precision))
 
     def antisymmetric_op(self) -> "XPPauli":
-        """
+        """Return the antisymmetric operator corresponding to the
+        z component of XP operator, only if x component is 0.
+
         Note:
             This method is adapted from method XPD from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
@@ -225,19 +244,29 @@ class XPPauli(BaseXPPauli):
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
 
+        Returns:
+            XPPauli: Antisymmetric operator corresponding to XPPauli, if x is 0
+
         See also:
             _antisymmetric_op
         """
         return XPPauli(super().antisymmetric_op())
 
     def power(self, n) -> "XPPauli":
-        """
+        """Return the XP operator of specified precision raised to the power n.
+
         Note:
             This method is adapted from method XPPower from XPFpackage:
             https://github.com/m-webster/XPFpackage, originally developed by
             Mark Webster. The original code is licensed under the GNU General
             Public License v3.0 and Mark Webster has given permission to use
             the code under the Apache License v2.0.
+
+        Args:
+            n: The power to which XPPauli is to be raised
+
+        Returns:
+            XPPauli: XPPauli raised to the power n
 
         See also:
             _power

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -285,7 +285,7 @@ class XPPauli(BaseXPPauli):
         """
         return XPPauli(super().antisymmetric_op())
 
-    def power(self, n) -> "XPPauli":
+    def power(self, n: int) -> "XPPauli":
         """Return the XP operator of specified precision raised to the power n.
 
         Note:

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -142,5 +142,8 @@ class XPPauli(BaseXPPauli):
     def antisymmetric_op(self):
         return XPPauli(super().antisymmetric_op())
 
+    def power(self, n):
+        return XPPauli(super().power(n))
+
 # Update docstrings for API docs
 generate_apidocs(XPPauli)

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -126,6 +126,9 @@ class XPPauli(BaseXPPauli):
     def z(self, val):
         self.matrix[:, self.num_qubits :][0] = val
 
+    # TODO: as of now, these methods just call the base class method. If no
+    # class-specific code is needed in these functions, it should be possible
+    # to remove this code.
     def unique_vector_rep(self):
         return super().unique_vector_rep()
 
@@ -134,6 +137,9 @@ class XPPauli(BaseXPPauli):
 
     def weight(self):
         return super().weight()
+
+    def is_diagonal(self):
+        return super().is_diagonal()
 
 # Update docstrings for API docs
 generate_apidocs(XPPauli)

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -24,6 +24,9 @@ from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
 class XPPauli(BaseXPPauli):
     """`XPPauli` inherits from `BaseXPPauli`"""
 
+    # Set the max XPPauli string size before truncation
+    _truncate__ = 50
+
     # pylint: disable=unused-argument
     def __init__(
         self,

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 # Part of the QEC framework
-"""Module for Pauli"""
+"""Module for XPPauli"""
 from typing import Any, List, Optional, Union
 
 import numpy as np
@@ -174,16 +174,16 @@ class XPPauli(BaseXPPauli):
 
     # ---------------------------------------------------------------------
 
-    def unique_vector_rep(self):
+    def unique_vector_rep(self) -> "XPPauli":
         return XPPauli(super().unique_vector_rep())
 
-    def rescale_precision(self, new_precision):
+    def rescale_precision(self, new_precision) -> "XPPauli":
         return XPPauli(super().rescale_precision(new_precision))
 
-    def antisymmetric_op(self):
+    def antisymmetric_op(self) -> "XPPauli":
         return XPPauli(super().antisymmetric_op())
 
-    def power(self, n):
+    def power(self, n) -> "XPPauli":
         return XPPauli(super().power(n))
 
 

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -46,6 +46,7 @@ class XPPauli(BaseXPPauli):
             x ([type], optional): [description]. Defaults to None.
             z ([type], optional): [description]. Defaults to None.
             phase_exponent ([type], optional): [description]. Defaults to None.
+            precision: Precision of XP operators. Must be an integer greater than or equal to two.
 
         Raises:
             QiskitError: Something went wrong.

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -57,6 +57,7 @@ class XPPauli(BaseXPPauli):
         elif isinstance(data, BaseXPPauli):
             matrix = data.matrix[:, :]
             phase_exp = data._phase_exp[:]
+            precision = data.precision
         # TODO: elif isinstance(data, (tuple, list)), isinstance(data, str),
         # isinstance(data, ScalarOp) may be implemented later, like Pauli class
         else:
@@ -126,20 +127,20 @@ class XPPauli(BaseXPPauli):
     def z(self, val):
         self.matrix[:, self.num_qubits :][0] = val
 
-    # TODO: as of now, these methods just call the base class method. If no
-    # class-specific code is needed in these functions, it should be possible
-    # to remove this code.
     def unique_vector_rep(self):
-        return super().unique_vector_rep()
+        return XPPauli(super().unique_vector_rep())
 
     def rescale_precision(self, new_precision):
-        return super().rescale_precision(new_precision)
+        return XPPauli(super().rescale_precision(new_precision))
 
     def weight(self):
         return super().weight()
 
     def is_diagonal(self):
         return super().is_diagonal()
+
+    def antisymmetric_op(self):
+        return XPPauli(super().antisymmetric_op())
 
 # Update docstrings for API docs
 generate_apidocs(XPPauli)

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -1,0 +1,137 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# Part of the QEC framework
+"""Module for Pauli"""
+from typing import Any, Dict, List, Optional, Union
+
+import numpy as np
+from qiskit.circuit import Instruction, QuantumCircuit
+from qiskit.circuit.barrier import Barrier
+from qiskit.circuit.delay import Delay
+from qiskit.circuit.library.generalized_gates import PauliGate
+from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
+from qiskit.exceptions import QiskitError
+from qiskit.quantum_info.operators.mixins import generate_apidocs
+from qiskit.quantum_info.operators.scalar_op import ScalarOp
+from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
+from qiskit_qec.utils import xp_pauli_rep
+
+
+class XPPauli(BaseXPPauli):
+    """`XPPauli` inherits from `BaseXPPauli`"""
+
+    def __init__(
+        self,
+        data: Any,
+        *,
+        x: Union[List, np.ndarray, None] = None,
+        z: Union[List, np.ndarray, None] = None,
+        phase_exp: Union[int, np.ndarray, None] = None,
+        precision: int = None,
+        input_xppauli_encoding: str = BaseXPPauli.EXTERNAL_XP_PAULI_ENCODING,
+    ):
+        """XPPauli Init
+
+        Args:
+            data (str): Still in progress
+            x ([type], optional): [description]. Defaults to None.
+            z ([type], optional): [description]. Defaults to None.
+            phase_exponent ([type], optional): [description]. Defaults to None.
+
+        Raises:
+            QiskitError: Something went wrong.
+        """
+        if isinstance(data, np.ndarray):
+            matrix = np.atleast_2d(data)
+            if phase_exp is None:
+                phase_exp = 0
+        elif isinstance(data, BaseXPPauli):
+            matrix = data.matrix[:, :]
+            phase_exp = data._phase_exp[:]
+        # TODO: elif isinstance(data, (tuple, list)), isinstance(data, str),
+        # isinstance(data, ScalarOp) may be implemented later, like Pauli class
+        else:
+            raise QiskitError("Invalid input data for XPPauli.")
+
+        # Initialize BaseXPPauli
+        if matrix.shape[0] != 1:
+            raise QiskitError("Input is not a single XPPauli")
+
+        super().__init__(matrix, phase_exp, precision)
+        self.vlist = self.matrix[0].tolist()
+
+    # ---------------------------------------------------------------------
+    # Property Methods
+    # ---------------------------------------------------------------------
+
+    @property
+    def name(self):
+        """Unique string identifier for operation type."""
+        return "xppauli"
+
+    # TODO: several @property methods exist in Pauli class, analogous methods
+    # may be added here later.
+
+    @property
+    def phase_exp(self):
+        """Return the group phase exponent for the Pauli."""
+        # Convert internal Pauli encoding to external Pauli encoding
+        # return pauli_rep.change_pauli_encoding(
+        #     self._phase_exp, self.num_y, output_pauli_encoding=BasePauli.EXTERNAL_PAULI_ENCODING
+        # )
+        pass
+
+    @phase_exp.setter
+    def phase_exp(self, value):
+        # Convert external Pauli encoding to the internal Pauli Encoding
+        # self._phase_exp[:] = pauli_rep.change_pauli_encoding(
+        #     value,
+        #     self.num_y,
+        #     input_pauli_encoding=BasePauli.EXTERNAL_PAULI_ENCODING,
+        #     output_pauli_encoding=pauli_rep.INTERNAL_PAULI_ENCODING,
+        #     same_type=False,
+        # )
+        pass
+
+    @property
+    def phase(self):
+        """Return the complex phase of the Pauli"""
+        # return pauli_rep.exp2cpx(self.phase_exp, input_encoding=BasePauli.EXTERNAL_PHASE_ENCODING)
+        pass
+
+    @property
+    def x(self):
+        """The x vector for the XPPauli."""
+        return self.matrix[:, : self.num_qubits][0]
+
+    @x.setter
+    def x(self, val):
+        self.matrix[:, : self.num_qubits][0] = val
+
+    @property
+    def z(self):
+        """The z vector for the XPPauli."""
+        return self.matrix[:, self.num_qubits :][0]
+
+    @z.setter
+    def z(self, val):
+        self.matrix[:, self.num_qubits :][0] = val
+
+    def unique_vector_rep(self):
+        return super().unique_vector_rep()
+
+    def rescale_precision(self, new_precision):
+        return super().rescale_precision(new_precision)
+
+
+# Update docstrings for API docs
+generate_apidocs(XPPauli)

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -11,24 +11,20 @@
 # that they have been altered from the originals.
 # Part of the QEC framework
 """Module for Pauli"""
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
-from qiskit.circuit import Instruction, QuantumCircuit
-from qiskit.circuit.barrier import Barrier
-from qiskit.circuit.delay import Delay
-from qiskit.circuit.library.generalized_gates import PauliGate
-from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.mixins import generate_apidocs
-from qiskit.quantum_info.operators.scalar_op import ScalarOp
 from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
-from qiskit_qec.utils import xp_pauli_rep
+
+# from qiskit_qec.utils import xp_pauli_rep
 
 
 class XPPauli(BaseXPPauli):
     """`XPPauli` inherits from `BaseXPPauli`"""
 
+    # pylint: disable=unused-argument
     def __init__(
         self,
         data: Any,
@@ -181,20 +177,12 @@ class XPPauli(BaseXPPauli):
     def rescale_precision(self, new_precision):
         return XPPauli(super().rescale_precision(new_precision))
 
-    def weight(self):
-        return super().weight()
-
-    def is_diagonal(self):
-        return super().is_diagonal()
-
     def antisymmetric_op(self):
         return XPPauli(super().antisymmetric_op())
 
     def power(self, n):
         return XPPauli(super().power(n))
 
-    def degree(self):
-        return super().degree()
 
 # Update docstrings for API docs
 generate_apidocs(XPPauli)

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -141,6 +141,13 @@ class XPPauli(BaseXPPauli):
     ) -> "XPPauli":
         """Return the operator composition with another XPPauli.
 
+        Note:
+            This method is adapted from method XPMul from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+
         Args:
             other (XPPauli): a XPPauli object.
             qargs (list or None): Optional, qubits to apply dot product
@@ -175,15 +182,47 @@ class XPPauli(BaseXPPauli):
     # ---------------------------------------------------------------------
 
     def unique_vector_rep(self) -> "XPPauli":
+        """
+        Note:
+            This method is adapted from the method XPRound from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return XPPauli(super().unique_vector_rep())
 
     def rescale_precision(self, new_precision) -> "XPPauli":
+        """
+        Note:
+            This method is adapted from the method XPSetN from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return XPPauli(super().rescale_precision(new_precision))
 
     def antisymmetric_op(self) -> "XPPauli":
+        """
+        Note:
+            This method is adapted from method XPD from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return XPPauli(super().antisymmetric_op())
 
     def power(self, n) -> "XPPauli":
+        """
+        Note:
+            This method is adapted from method XPPower from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+        """
         return XPPauli(super().power(n))
 
 

--- a/qiskit_qec/operators/xp_pauli.py
+++ b/qiskit_qec/operators/xp_pauli.py
@@ -132,6 +132,8 @@ class XPPauli(BaseXPPauli):
     def rescale_precision(self, new_precision):
         return super().rescale_precision(new_precision)
 
+    def weight(self):
+        return super().weight()
 
 # Update docstrings for API docs
 generate_apidocs(XPPauli)

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -26,7 +26,7 @@ from qiskit_qec.utils import xp_pauli_rep
 class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
     """`XPPauliList` inherits from `BaseXPPauli`"""
 
-    # Set the max number of qubits * paulis before string truncation
+    # Set the max number of qubits * xppaulis before string truncation
     _truncate__ = 2000
 
     def __init__(

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -272,12 +272,16 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             QiskitError: if other cannot be converted to a XPPauliList, does
                          not have either 1 or the same number of XPPaulis as
                          the current list, has the wrong number of qubits
-                         for the specified qargs, or if precision of other 
+                         for the specified qargs, or if precision of other
                          does not match precision of self.
 
         Examples:
-            >>> a = XPPauliList(data=np.array([[0, 1, 0, 0, 2, 0], [0, 1, 0, 0, 2, 0]], dtype=np.int64), phase_exp=np.array([6, 6]), precision=4)
-            >>> b = XPPauliList(data=np.array([[1, 1, 1, 3, 3, 0], [1, 1, 1, 3, 3, 0]], dtype=np.int64), phase_exp=np.array([2, 2]), precision=4)
+            >>> a = XPPauliList(
+            ... data=np.array([[0, 1, 0, 0, 2, 0], [0, 1, 0, 0, 2, 0]], dtype=np.int64),
+            ... phase_exp=np.array([6, 6]), precision=4)
+            >>> b = XPPauliList(
+            ... data=np.array([[1, 1, 1, 3, 3, 0], [1, 1, 1, 3, 3, 0]], dtype=np.int64),
+            ... phase_exp=np.array([2, 2]), precision=4)
             >>> value = XPPauliList.compose(a, b)
             >>> value.matrix
             array([[1, 0, 1, 3, 3, 0], [1, 0, 1, 3, 3, 0]], dtype=int64)
@@ -297,11 +301,13 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
                 "have either 1 or the same number of XPPaulis."
             )
         if self.precision != other.precision:
-            raise QiskitError("Precision of the two XPPauliLists to be multiplied must be the same.")
+            raise QiskitError(
+                "Precision of the two XPPauliLists to be multiplied must be the same."
+            )
 
         return XPPauliList(super().compose(other, qargs=qargs, front=front, inplace=inplace))
 
-    def rescale_precision(self, new_precision) -> "XPPauliList":
+    def rescale_precision(self, new_precision: int) -> "XPPauliList":
         """Rescale the generalized symplectic vector components
         of XPPauli operator to the new precision. Returns the rescaled XPPauli object.
 
@@ -319,7 +325,7 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             XPPauliList: Resultant of rescaling the precision of XPPauliList
 
         Raises:
-            QiskitError: If it is not possible to express XPPauli in new_precision 
+            QiskitError: If it is not possible to express XPPauliList in new_precision
 
         Examples:
             >>> matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
@@ -333,7 +339,8 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             >>> xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
             >>> rescaled_xppauli_list = xppaulilist.rescale_precision(new_precision=new_precision)
             >>> rescaled_xppauli_list.matrix
-            array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0], [1, 1, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3]] dtype=np.int64)
+            array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0],
+                [1, 1, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3]] dtype=np.int64)
             >>> rescaled_xppauli_list._phase_exp
             array([6, 4])
 
@@ -357,13 +364,15 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             XPPauliList: Antisymmetric operator corresponding to XPPauliList, if x is 0
 
         Examples:
-            >>> matrix = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], [0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3, 7, 6, 3]], dtype=np.int64)
+            >>> matrix = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3],
+            ... [0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3, 7, 6, 3]], dtype=np.int64)
             >>> phase_exp = np.array([0, 0])
             >>> precision = 8
             >>> xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
             >>> value = xppauli_list.antisymmetric_op()
             >>> value.matrix
-            array([[0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], [0, 0, 0, 0, 0, 0, 0, -3, -1, -2, -3, -7, -6, -3]], dtype=np.int64)
+            array([[0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3],
+                [0, 0, 0, 0, 0, 0, 0, -3, -1, -2, -3, -7, -6, -3]], dtype=np.int64)
             >>> value._phase_exp
             array([15, 25])
 
@@ -389,14 +398,16 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             XPPauliList: XPPauliList raised to the power n
 
         Examples:
-            >>> matrix = np.array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1]], dtype=np.int64)
+            >>> matrix = np.array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1],
+            ... [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1]], dtype=np.int64)
             >>> phase_exp = np.array([12, 12])
             >>> precision = 8
             >>> n = 5
             >>> xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
             >>> value = xppauli_list.power(n=n)
             >>> value.matrix
-            array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5]] ,dtype=np.int64)
+            array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5],
+                [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5]] ,dtype=np.int64)
             >>> value._phase_exp
             np.array([8, 8])
 

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -275,6 +275,15 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
                          for the specified qargs, or if precision of other 
                          does not match precision of self.
 
+        Examples:
+            >>> a = XPPauliList(data=np.array([[0, 1, 0, 0, 2, 0], [0, 1, 0, 0, 2, 0]], dtype=np.int64), phase_exp=np.array([6, 6]), precision=4)
+            >>> b = XPPauliList(data=np.array([[1, 1, 1, 3, 3, 0], [1, 1, 1, 3, 3, 0]], dtype=np.int64), phase_exp=np.array([2, 2]), precision=4)
+            >>> value = XPPauliList.compose(a, b)
+            >>> value.matrix
+            array([[1, 0, 1, 3, 3, 0], [1, 0, 1, 3, 3, 0]], dtype=int64)
+            >>> value._phase_exp
+            array([6, 6])
+
         See also:
             _compose
         """

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -252,6 +252,13 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
     ) -> "XPPauliList":
         """Return the composition self∘other for each XPPauli in the list.
 
+        Note:
+            This method is adapted from the method XPMul from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+
         Args:
             other (XPPauliList): another XPPauliList.
             qargs (None or list): qubits to apply dot product on (Default: None).

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -10,6 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 # Part of the QEC framework
+#
+# This code is based on the paper: "The XP Stabiliser Formalism: a
+# Generalisation of the Pauli Stabiliser Formalism with Arbitrary Phases", Mark
+# A. Webster, Benjamin J. Brown, and Stephen D. Bartlett. Quantum 6, 815
+# (2022).
 """Module for XPPauli List"""
 import numbers
 from typing import Iterable, List, Tuple, Union, Optional

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -19,7 +19,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.mixins import GroupMixin, LinearMixin
 from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
 from qiskit_qec.operators.xp_pauli import XPPauli
-from qiskit_qec.utils import pauli_rep
+from qiskit_qec.utils import xp_pauli_rep
 
 
 class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
@@ -34,6 +34,7 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             BaseXPPauli, np.ndarray, Tuple[np.ndarray], Iterable, None
         ] = None,
         phase_exp: Union[int, np.ndarray, None] = None,
+        precision: Union[int, np.ndarray] = None,
         *,
         input_pauli_encoding: str = BaseXPPauli.EXTERNAL_XP_PAULI_ENCODING,
         input_qubit_order: str = "right-to-left",
@@ -45,6 +46,7 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             data (str): List of XPPauli Operators.
             phase_exp (int, optional): i**phase_exp. Defaults to 0.
             input_qubit_order (str, optional): Order to read pdata. Defaults to "right-to-left".
+            precision: Precision of XP operators. Must be an integer/array of integers greater than or equal to 2.
 
         Raises:
             QiskitError: Something went wrong.
@@ -55,25 +57,25 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
         elif isinstance(data, BaseXPPauli):
             matrix = data.matrix
             phase_exp = data._phase_exp
+            precision = data.precision
         # TODO elif isinstance(data, StabilizerTable), elif isinstance(data, PauliTable)
         elif isinstance(data, np.ndarray):
             if data.size == 0:
                 matrix = np.empty(shape=(0, 0), dtype=np.bool_)
                 phase_exp = np.empty(shape=(0,), dtype=np.int8)
-            elif isinstance(data[0], str):
-                matrix, phase_exp = self._from_paulis(data, input_qubit_order)
+            # TODO elif isinstance(data[0], str):
             else:
                 if phase_exp is None:
                     phase_exp = 0
-                matrix, phase_exp = pauli_rep.from_array(
-                    data, phase_exp, input_pauli_encoding=input_pauli_encoding
+                matrix, phase_exp, precision = xp_pauli_rep.from_array(
+                    data, phase_exp, precision, input_pauli_encoding=input_pauli_encoding
                 )
         # TODO elif isinstance(data, tuple)
         else:
             # TODO Conversion as iterable of Paulis
             pass
 
-        super().__init__(matrix, phase_exp)
+        super().__init__(matrix, phase_exp, precision)
 
         # TODO
         # self.paulis = [
@@ -206,6 +208,10 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
     def __len__(self):
         """Return the number of XPPauli rows in the table."""
         return self._num_paulis
+
+    def _add(self, other, qargs=None):
+        """summary"""
+        pass
 
     # ----
     #

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -301,6 +301,110 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
 
         return XPPauliList(super().compose(other, qargs=qargs, front=front, inplace=inplace))
 
+    def rescale_precision(self, new_precision) -> "XPPauliList":
+        """Rescale the generalized symplectic vector components
+        of XPPauli operator to the new precision. Returns the rescaled XPPauli object.
+
+        Note:
+            This method is adapted from method XPSetN from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+
+        Args:
+            new_precision: The target precision in which XPPauli is to be expressed
+
+        Returns:
+            XPPauliList: Resultant of rescaling the precision of XPPauliList
+
+        Raises:
+            QiskitError: If it is not possible to express XPPauli in new_precision 
+
+        Examples:
+            >>> matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
+            >>> phase_exp1 = 12
+            >>> matrix2 = np.array([1, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 6], dtype=np.int64)
+            >>> phase_exp2 = 8
+            >>> precision = 8
+            >>> new_precision = 4
+            >>> matrix = np.array([matrix1, matrix2])
+            >>> phase_exp = np.array([phase_exp1, phase_exp2])
+            >>> xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+            >>> rescaled_xppauli_list = xppaulilist.rescale_precision(new_precision=new_precision)
+            >>> rescaled_xppauli_list.matrix
+            array([[1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0], [1, 1, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3]] dtype=np.int64)
+            >>> rescaled_xppauli_list._phase_exp
+            array([6, 4])
+
+        See also:
+            _rescale_precision
+        """
+        return XPPauliList(super().rescale_precision(new_precision))
+
+    def antisymmetric_op(self) -> "XPPauliList":
+        """Return the antisymmetric operator corresponding to the
+        z component of XP operator, only if x component is 0.
+
+        Note:
+            This method is adapted from method XPD from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+
+        Returns:
+            XPPauliList: Antisymmetric operator corresponding to XPPauliList, if x is 0
+
+        Examples:
+            >>> matrix = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], [0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3, 7, 6, 3]], dtype=np.int64)
+            >>> phase_exp = np.array([0, 0])
+            >>> precision = 8
+            >>> xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+            >>> value = xppauli_list.antisymmetric_op()
+            >>> value.matrix
+            array([[0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], [0, 0, 0, 0, 0, 0, 0, -3, -1, -2, -3, -7, -6, -3]], dtype=np.int64)
+            >>> value._phase_exp
+            array([15, 25])
+
+        See also:
+            _antisymmetric_op
+        """
+        return XPPauliList(super().antisymmetric_op())
+
+    def power(self, n: int) -> "XPPauliList":
+        """Return the XP operator of specified precision raised to the power n.
+
+        Note:
+            This method is adapted from method XPPower from XPFpackage:
+            https://github.com/m-webster/XPFpackage, originally developed by
+            Mark Webster. The original code is licensed under the GNU General
+            Public License v3.0 and Mark Webster has given permission to use
+            the code under the Apache License v2.0.
+
+        Args:
+            n: The power to which XPPauliList is to be raised
+
+        Returns:
+            XPPauliList: XPPauliList raised to the power n
+
+        Examples:
+            >>> matrix = np.array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1]], dtype=np.int64)
+            >>> phase_exp = np.array([12, 12])
+            >>> precision = 8
+            >>> n = 5
+            >>> xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+            >>> value = xppauli_list.power(n=n)
+            >>> value.matrix
+            array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5]] ,dtype=np.int64)
+            >>> value._phase_exp
+            np.array([8, 8])
+
+        See also:
+            _power
+        """
+        return XPPauliList(super().power(n))
+
     # def conjugate(self):
     #     """Return the conjugate of each XPPauli in the list."""
     #     # TODO

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -1,0 +1,314 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# Part of the QEC framework
+"""Module for XPPauli List"""
+import numbers
+from typing import Iterable, List, Tuple, Union
+
+import numpy as np
+from qiskit.exceptions import QiskitError
+from qiskit.quantum_info.operators.mixins import GroupMixin, LinearMixin
+from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
+from qiskit_qec.operators.xp_pauli import XPPauli
+from qiskit_qec.utils import pauli_rep
+
+
+class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
+    """`XPPauliList` inherits from `BaseXPPauli`"""
+
+    # Set the max number of qubits * paulis before string truncation
+    _truncate__ = 2000
+
+    def __init__(
+        self,
+        data: Union[
+            BaseXPPauli, np.ndarray, Tuple[np.ndarray], Iterable, None
+        ] = None,
+        phase_exp: Union[int, np.ndarray, None] = None,
+        *,
+        input_pauli_encoding: str = BaseXPPauli.EXTERNAL_XP_PAULI_ENCODING,
+        input_qubit_order: str = "right-to-left",
+        tuple_order: str = "zx",
+    ) -> None:
+        """Inits a XPPauliList
+
+        Args:
+            data (str): List of XPPauli Operators.
+            phase_exp (int, optional): i**phase_exp. Defaults to 0.
+            input_qubit_order (str, optional): Order to read pdata. Defaults to "right-to-left".
+
+        Raises:
+            QiskitError: Something went wrong.
+        """
+        if data is None:
+            matrix = np.empty(shape=(0, 0), dtype=np.bool_)
+            phase_exp = np.empty(shape=(0,), dtype=np.int8)
+        elif isinstance(data, BaseXPPauli):
+            matrix = data.matrix
+            phase_exp = data._phase_exp
+        # TODO elif isinstance(data, StabilizerTable), elif isinstance(data, PauliTable)
+        elif isinstance(data, np.ndarray):
+            if data.size == 0:
+                matrix = np.empty(shape=(0, 0), dtype=np.bool_)
+                phase_exp = np.empty(shape=(0,), dtype=np.int8)
+            elif isinstance(data[0], str):
+                matrix, phase_exp = self._from_paulis(data, input_qubit_order)
+            else:
+                if phase_exp is None:
+                    phase_exp = 0
+                matrix, phase_exp = pauli_rep.from_array(
+                    data, phase_exp, input_pauli_encoding=input_pauli_encoding
+                )
+        # TODO elif isinstance(data, tuple)
+        else:
+            # TODO Conversion as iterable of Paulis
+            pass
+
+        super().__init__(matrix, phase_exp)
+
+        # TODO
+        # self.paulis = [
+        #     Pauli(self.matrix[i], phase_exp=self._phase_exp[i]) for i in range(self.matrix.shape[0])
+        # ]
+
+    # ---------------------------------------------------------------------
+    # Init Methods
+    # ---------------------------------------------------------------------
+
+    # ---------------------------------------------------------------------
+    # Property Methods
+    # ---------------------------------------------------------------------
+
+    @property
+    def phase(self):
+        """Return the phase vector of the XPPauliList.
+
+        Note: This is different from the quantum_info phase property which
+        instead returns the phase_exp
+        """
+        # TODO
+        pass
+
+    @phase.setter
+    def phase(self, phase):
+        """Set the phase vector of the XPPauliList
+
+        Args:
+            phase (numpy.ndarray or complex numbers): Array of phases,
+                phases must be one of [1,-1, 1j, -1j]
+        """
+        # TODO
+        pass
+
+    @property
+    def shape(self):
+        """The full shape of the :meth:`array`"""
+        return self._num_paulis, self.num_qubits
+
+    @property
+    def size(self):
+        """The number of XPPauli rows in the table."""
+        return self._num_paulis
+
+    @property
+    def num_paulis(self):
+        """Returns the number of XPPauli's in List"""
+        return self._num_paulis
+
+    @property
+    def phase_exp(self):
+        """Return the phase exponent vector of the XPPauliList"""
+        # TODO
+        pass
+
+    @phase_exp.setter
+    def phase_exp(self, phase_exp, input_phase_encoding=BaseXPPauli.EXTERNAL_PHASE_ENCODING):
+        """Set the phase exponent vector of the XPPauliList. Note that this method
+        converts the phase exponents directly and does not take into account the
+        number of Y paulis in the representation.
+
+        Args:
+            phase_exp (_type_): _description_
+            input_phase_encoding (_type_, optional): _description_. Defaults to
+                BaseXPPauli.EXTERNAL_PHASE_ENCODING.
+        """
+        # TODO
+        pass
+
+    @property
+    def settings(self):
+        """Return settings."""
+        return {"data": self.to_labels()}
+
+    # ---------------------------------------------------------------------
+    # Magic Methods and related methods
+    # ---------------------------------------------------------------------
+
+    def __getitem__(self, index):
+        """Return a view of the XPPauliList."""
+        # Returns a view of specified rows of the XPPauliList
+        # This supports all slicing operations the underlying array supports.
+        # TODO
+        pass
+
+    def getaslist(self, slc: Union[numbers.Integral, slice]) -> List["XPPauli"]:
+        """_summary_
+
+        Returns:
+            _type_: _description_
+        """
+        # TODO
+        pass
+
+    def __setitem__(self, index, value):
+        """Update XPPauliList."""
+        # TODO
+        pass
+
+    def __repr__(self):
+        """Display representation."""
+        return self._truncated_str(True)
+
+    def __str__(self):
+        """Print representation."""
+        return self._truncated_str(False)
+
+    def _truncated_str(self, show_class):
+        # TODO
+        pass
+
+    def __array__(self, dtype=None):
+        """Convert to numpy array"""
+        # pylint: disable=unused-argument
+        shape = (len(self),) + 2 * (2**self.num_qubits,)
+        ret = np.zeros(shape, dtype=complex)
+        for i, mat in enumerate(self.matrix_iter()):
+            ret[i] = mat
+        return ret
+
+    def __eq__(self, other):
+        """Entrywise comparison of XPPauli equality."""
+        if not isinstance(other, XPPauliList):
+            other = XPPauliList(other)
+        if not isinstance(other, BaseXPPauli):
+            return False
+        return self._eq(other)
+
+    def __len__(self):
+        """Return the number of XPPauli rows in the table."""
+        return self._num_paulis
+
+    # ----
+    #
+    # ----
+
+    # ---------------------------------------------------------------------
+    # BaseOperator methods
+    # ---------------------------------------------------------------------
+
+    def tensor(self, other):
+        """Return the tensor product with each XPPauli in the list.
+
+        Args:
+            other (XPPauliList): another XPPauliList.
+
+        Returns:
+            XPPauliList: the list of tensor product XPPaulis.
+
+        Raises:
+            QiskitError: if other cannot be converted to a XPPauliList, does
+                         not have either 1 or the same number of XPPaulis as
+                         the current list.
+        """
+        # TODO
+        pass
+
+    def compose(self, other, qargs=None, front=False, inplace=False):
+        """Return the composition self∘other for each XPPauli in the list.
+
+        Args:
+            other (XPPauliList): another XPPauliList.
+            qargs (None or list): qubits to apply dot product on (Default: None).
+            front (bool): If True use `dot` composition method [default: False].
+            inplace (bool): If True update in-place (default: False).
+
+        Returns:
+            XPPauliList: the list of composed XPPaulis.
+
+        Raises:
+            QiskitError: if other cannot be converted to a XPPauliList, does
+                         not have either 1 or the same number of XPPaulis as
+                         the current list, or has the wrong number of qubits
+                         for the specified qargs.
+        """
+        if qargs is None:
+            qargs = getattr(other, "qargs", None)
+        if not isinstance(other, XPPauliList):
+            other = XPPauliList(other)
+        if len(other) not in [1, len(self)]:
+            raise QiskitError(
+                "Incompatible XPPauliLists. Other list must "
+                "have either 1 or the same number of XPPaulis."
+            )
+        return XPPauliList(super().compose(other, qargs=qargs, front=front, inplace=inplace))
+
+    def conjugate(self):
+        """Return the conjugate of each XPPauli in the list."""
+        # TODO
+        pass
+
+    def transpose(self):
+        """Return the transpose of each XPPauli in the list."""
+        # TODO
+        pass
+
+    def adjoint(self):
+        """Return the adjoint of each XPPauli in the list."""
+        # TODO
+        pass
+
+    def inverse(self):
+        """Return the inverse of each XPPauli in the list."""
+        # TODO
+        pass
+
+    # ---------------------------------------------------------------------
+    # Utility methods
+    # ---------------------------------------------------------------------
+
+    # ---------------------------------------------------------------------
+    # Custom Iterators
+    # ---------------------------------------------------------------------
+
+    # ---------------------------------------------------------------------
+    # Class methods
+    # ---------------------------------------------------------------------
+
+    @classmethod
+    def from_symplectic(cls, z, x, phase_exp=0):
+        """Construct a XPPauliList from a symplectic data.
+
+        Args:
+            z (np.ndarray): 2D boolean Numpy array.
+            x (np.ndarray): 2D boolean Numpy array.
+            phase_exp (np.ndarray or None): Optional, 1D integer array from Z_4.
+
+        Returns:
+            XPPauliList: the constructed XPPauliList.
+
+        Note: Initialization this way will copy matrices and not reference them.
+
+        TODO: Fix this method to be more general and not in old form only
+            (i.e. include matrix inputs ...)
+        """
+        # TODO
+        pass

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -114,17 +114,17 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
     @property
     def shape(self):
         """The full shape of the :meth:`array`"""
-        return self._num_paulis, self.num_qubits
+        return self._num_xppaulis, self.num_qubits
 
     @property
     def size(self):
         """The number of XPPauli rows in the table."""
-        return self._num_paulis
+        return self._num_xppaulis
 
     @property
-    def num_paulis(self):
+    def num_xppaulis(self):
         """Returns the number of XPPauli's in List"""
-        return self._num_paulis
+        return self._num_xppaulis
 
     @property
     def phase_exp(self):
@@ -207,7 +207,7 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
 
     def __len__(self):
         """Return the number of XPPauli rows in the table."""
-        return self._num_paulis
+        return self._num_xppaulis
 
     def _add(self, other, qargs=None):
         """summary"""

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -12,7 +12,7 @@
 # Part of the QEC framework
 """Module for XPPauli List"""
 import numbers
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable, List, Tuple, Union, Optional
 
 import numpy as np
 from qiskit.exceptions import QiskitError
@@ -122,7 +122,7 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
         return self._num_xppaulis
 
     @property
-    def num_xppaulis(self):
+    def num_xppaulis(self) -> int:
         """Returns the number of XPPauli's in List"""
         return self._num_xppaulis
 
@@ -238,7 +238,13 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
         # TODO
         pass
 
-    def compose(self, other, qargs=None, front=False, inplace=False):
+    def compose(
+        self,
+        other: "BaseXPPauli",
+        qargs: Optional[list] = None,
+        front: bool = False,
+        inplace: bool = False,
+    ) -> "XPPauliList":
         """Return the composition self∘other for each XPPauli in the list.
 
         Args:

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -271,8 +271,9 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
         Raises:
             QiskitError: if other cannot be converted to a XPPauliList, does
                          not have either 1 or the same number of XPPaulis as
-                         the current list, or has the wrong number of qubits
-                         for the specified qargs.
+                         the current list, has the wrong number of qubits
+                         for the specified qargs, or if precision of other 
+                         does not match precision of self.
 
         See also:
             _compose
@@ -286,6 +287,9 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
                 "Incompatible XPPauliLists. Other list must "
                 "have either 1 or the same number of XPPaulis."
             )
+        if self.precision != other.precision:
+            raise QiskitError("Precision of the two XPPauliLists to be multiplied must be the same.")
+
         return XPPauliList(super().compose(other, qargs=qargs, front=front, inplace=inplace))
 
     # def conjugate(self):

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -18,10 +18,11 @@ import numpy as np
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.mixins import GroupMixin, LinearMixin
 from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
-from qiskit_qec.operators.xp_pauli import XPPauli
 from qiskit_qec.utils import xp_pauli_rep
 
 
+# pylint: disable=unused-argument
+# pylint: disable=no-member
 class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
     """`XPPauliList` inherits from `BaseXPPauli`"""
 
@@ -30,9 +31,7 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
 
     def __init__(
         self,
-        data: Union[
-            BaseXPPauli, np.ndarray, Tuple[np.ndarray], Iterable, None
-        ] = None,
+        data: Union[BaseXPPauli, np.ndarray, Tuple[np.ndarray], Iterable, None] = None,
         phase_exp: Union[int, np.ndarray, None] = None,
         precision: Union[int, np.ndarray] = None,
         *,
@@ -46,7 +45,8 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             data (str): List of XPPauli Operators.
             phase_exp (int, optional): i**phase_exp. Defaults to 0.
             input_qubit_order (str, optional): Order to read pdata. Defaults to "right-to-left".
-            precision: Precision of XP operators. Must be an integer/array of integers greater than or equal to 2.
+            precision: Precision of XP operators. Must be an integer/array of
+            integers greater than or equal to 2.
 
         Raises:
             QiskitError: Something went wrong.
@@ -267,25 +267,25 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
             )
         return XPPauliList(super().compose(other, qargs=qargs, front=front, inplace=inplace))
 
-    def conjugate(self):
-        """Return the conjugate of each XPPauli in the list."""
-        # TODO
-        pass
+    # def conjugate(self):
+    #     """Return the conjugate of each XPPauli in the list."""
+    #     # TODO
+    #     pass
 
-    def transpose(self):
-        """Return the transpose of each XPPauli in the list."""
-        # TODO
-        pass
+    # def transpose(self):
+    #     """Return the transpose of each XPPauli in the list."""
+    #     # TODO
+    #     pass
 
-    def adjoint(self):
-        """Return the adjoint of each XPPauli in the list."""
-        # TODO
-        pass
+    # def adjoint(self):
+    #     """Return the adjoint of each XPPauli in the list."""
+    #     # TODO
+    #     pass
 
-    def inverse(self):
-        """Return the inverse of each XPPauli in the list."""
-        # TODO
-        pass
+    # def inverse(self):
+    #     """Return the inverse of each XPPauli in the list."""
+    #     # TODO
+    #     pass
 
     # ---------------------------------------------------------------------
     # Utility methods

--- a/qiskit_qec/operators/xp_pauli_list.py
+++ b/qiskit_qec/operators/xp_pauli_list.py
@@ -273,6 +273,9 @@ class XPPauliList(BaseXPPauli, LinearMixin, GroupMixin):
                          not have either 1 or the same number of XPPaulis as
                          the current list, or has the wrong number of qubits
                          for the specified qargs.
+
+        See also:
+            _compose
         """
         if qargs is None:
             qargs = getattr(other, "qargs", None)

--- a/qiskit_qec/utils/xp_pauli_rep.py
+++ b/qiskit_qec/utils/xp_pauli_rep.py
@@ -690,15 +690,35 @@ def str2str(
 # ----------------------------------------------------------------------
 
 
-# pylint: disable=unused-argument
 def from_array(
     matrix: Union[List, Tuple, np.ndarray],
     phase_exp: Union[int, List, Tuple, np.ndarray] = None,
+    precision: Union[int, List, Tuple, np.ndarray] = None,
     input_pauli_encoding: Optional[str] = None,
-) -> Tuple[np.ndarray, np.ndarray]:
-    """_summary_"""
-    pass
-
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Convert array and phase_exp to the matrix, phase_exp and precision in BaseXPPauli's internal
+    XPPauli encoding (xp_pauli_rep.INTERNAL_XP_PAULI_ENCODING)
+    Args:
+        matrix (_type_): _description_
+        phase_exp (_type_): _description_
+        input_pauli_encoding: input XPPauli encoding
+    Returns:
+        _type_: _description_
+    """
+    if input_pauli_encoding is None:
+        input_pauli_encoding = DEFAULT_EXTERNAL_XP_PAULI_ENCODING
+    if isinstance(matrix, np.ndarray) and matrix.dtype == np.int64:
+        matrix_data = matrix
+    else:
+        matrix_data = np.asarray(matrix, dtype=np.int64)
+    matrix_data = np.atleast_2d(matrix_data)
+    # TODO
+    # if not is_symplectic_matrix_form(matrix_data):
+    #     raise QiskitError("Input matrix not a symplectic matrix or symplectic vector")
+    if phase_exp is None or (isinstance(phase_exp, numbers.Integral) and phase_exp == 0):
+        phase_exp = np.zeros(shape=(matrix_data.shape[0],))
+    # TODO may need to implement change_pauli_encoding
+    return matrix_data, phase_exp, precision
 
 # pylint: disable=unused-argument
 def from_split_array(

--- a/qiskit_qec/utils/xp_pauli_rep.py
+++ b/qiskit_qec/utils/xp_pauli_rep.py
@@ -701,6 +701,7 @@ def from_array(
     Args:
         matrix (_type_): _description_
         phase_exp (_type_): _description_
+        precision (_type_): Precision of XP operator
         input_pauli_encoding: input XPPauli encoding
     Returns:
         _type_: _description_
@@ -719,6 +720,7 @@ def from_array(
         phase_exp = np.zeros(shape=(matrix_data.shape[0],))
     # TODO may need to implement change_pauli_encoding
     return matrix_data, phase_exp, precision
+
 
 # pylint: disable=unused-argument
 def from_split_array(

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -125,5 +125,20 @@ class TestXPPauli(QiskitTestCase):
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
         self.assertEqual(value, target)
 
+    def test_power(self):
+        """Test power method."""
+        matrix = np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64)
+        phase_exp = 12
+        precision = 8
+        n = 5
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli.power(n=n)
+
+        target_matrix = np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], dtype=np.int64)
+        target_phase_exp = 15
+        target_precision = 8
+        target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        self.assertEqual(value, target)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -110,5 +110,20 @@ class TestXPPauli(QiskitTestCase):
         target = np.array([False])
         self.assertEqual(value, target)
 
+    def test_antisymmetric_op(self):
+        """Test antisymmetric_op method."""
+
+        matrix = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], dtype=np.int64)
+        phase_exp = 0
+        precision = 8
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli.antisymmetric_op()
+
+        target_matrix = np.array([0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], dtype=np.int64)
+        target_phase_exp = 15
+        target_precision = 8
+        target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        self.assertEqual(value, target)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -157,7 +157,17 @@ class TestXPPauli(QiskitTestCase):
         target_phase_exp = 6
         target_precision = 4
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        self.assertEqual(target, value)
 
+    def test_degree(self):
+        """Test degree method."""
+        matrix = np.array([0,0,0,2,1,0], dtype=np.int64)
+        phase_exp = 2
+        precision = 4
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli.degree()
+
+        target = 4
         self.assertEqual(target, value)
 
 if __name__ == "__main__":

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -71,6 +71,16 @@ class TestXPPauli(QiskitTestCase):
         np.testing.assert_equal(target_xppauli.matrix, rescaled_xppauli.matrix)
         np.testing.assert_equal(target_xppauli._phase_exp, rescaled_xppauli._phase_exp)
         np.testing.assert_equal(target_xppauli.precision, rescaled_xppauli.precision)
+
+    def test_weight(self):
+        """Test weight method."""
+        matrix = np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64)
+        phase_exp = 12
+        precision = 8
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli.weight()
+        target = 2
+        self.assertEqual(value, target)
         
 
 if __name__ == "__main__":

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -115,7 +115,9 @@ class TestXPPauli(QiskitTestCase):
         target_phase_exp = 15
         target_precision = 8
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
-        self.assertEqual(target, value)
+        np.testing.assert_equal(target.matrix, value.matrix)
+        np.testing.assert_equal(target._phase_exp, value._phase_exp)
+        np.testing.assert_equal(target.precision, value.precision)
 
     def test_power(self):
         """Test power method."""
@@ -127,10 +129,12 @@ class TestXPPauli(QiskitTestCase):
         value = xppauli.power(n=n)
 
         target_matrix = np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], dtype=np.int64)
-        target_phase_exp = 15
+        target_phase_exp = 8
         target_precision = 8
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
-        self.assertEqual(target, value)
+        np.testing.assert_equal(target.matrix, value.matrix)
+        np.testing.assert_equal(target._phase_exp, value._phase_exp)
+        np.testing.assert_equal(target.precision, value.precision)
 
     def test_multiplication(self):
         """Test multiplication method."""
@@ -149,7 +153,9 @@ class TestXPPauli(QiskitTestCase):
         target_phase_exp = 6
         target_precision = 4
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
-        self.assertEqual(target, value)
+        np.testing.assert_equal(target.matrix, value.matrix)
+        np.testing.assert_equal(target._phase_exp, value._phase_exp)
+        np.testing.assert_equal(target.precision, value.precision)
 
     def test_degree(self):
         """Test degree method."""

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -80,7 +80,7 @@ class TestXPPauli(QiskitTestCase):
         xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppauli.weight()
         target = 5
-        self.assertEqual(value, target)
+        self.assertEqual(target, value)
 
     def test_diagonal(self):
         """Test is_diagonal method."""
@@ -91,7 +91,7 @@ class TestXPPauli(QiskitTestCase):
         xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppauli.is_diagonal()
         target = np.array([True])
-        self.assertEqual(value, target)
+        self.assertEqual(target, value)
 
         # Test case taken from Mark's paper, Table 5.
         matrix = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
@@ -100,7 +100,7 @@ class TestXPPauli(QiskitTestCase):
         xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppauli.is_diagonal()
         target = np.array([True])
-        self.assertEqual(value, target)
+        self.assertEqual(target, value)
 
         matrix = np.array([0, 1, 0, 1, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
         phase_exp = 12
@@ -108,7 +108,7 @@ class TestXPPauli(QiskitTestCase):
         xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppauli.is_diagonal()
         target = np.array([False])
-        self.assertEqual(value, target)
+        self.assertEqual(target, value)
 
     def test_antisymmetric_op(self):
         """Test antisymmetric_op method."""
@@ -123,7 +123,7 @@ class TestXPPauli(QiskitTestCase):
         target_phase_exp = 15
         target_precision = 8
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
-        self.assertEqual(value, target)
+        self.assertEqual(target, value)
 
     def test_power(self):
         """Test power method."""
@@ -138,7 +138,27 @@ class TestXPPauli(QiskitTestCase):
         target_phase_exp = 15
         target_precision = 8
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
-        self.assertEqual(value, target)
+        self.assertEqual(target, value)
+
+    def test_multiplication(self):
+        """Test multiplication method."""
+        # Test case taken from Mark's code.
+        a_matrix = np.array([0,1,0,0,2,0], dtype=np.int64)
+        a_phase_exp = 6
+        a_precision = 4
+        a = XPPauli(data=a_matrix, phase_exp=a_phase_exp, precision=a_precision)
+        b_matrix = np.array([1,1,1,3,3,0], dtype=np.int64)
+        b_phase_exp = 2
+        b_precision = 4
+        b = XPPauli(data=b_matrix, phase_exp=b_phase_exp, precision=b_precision)
+        value = XPPauli.compose(a, b)
+
+        target_matrix = np.array([1,0,1,3,3,0], dtype=np.int64)
+        target_phase_exp = 6
+        target_precision = 4
+        target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+
+        self.assertEqual(target, value)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -1,0 +1,77 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=invalid-name
+
+"""Tests for Pauli operator class."""
+
+import unittest
+import itertools as it
+from functools import lru_cache
+
+import numpy as np
+from ddt import ddt, data, unpack
+
+from qiskit import QuantumCircuit
+from qiskit.exceptions import QiskitError
+from qiskit.test import QiskitTestCase
+
+from qiskit.quantum_info.operators import Operator
+
+from qiskit_qec.operators.random import random_clifford, random_pauli, random_xppauli
+from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
+from qiskit_qec.operators.xp_pauli import XPPauli
+
+# TODO from qiskit_qec.utils.pauli_rep import split_pauli, cpxstr2exp
+
+# from qiskit.quantum_info.operators.symplectic.pauli import _split_pauli_label, _phase_from_label
+
+
+@ddt 
+class TestXPPauliInit(QiskitTestCase):
+    """Tests for XPPauli initialization."""
+
+    def test_array_init(self):
+        """Test array initialization."""
+        # Test case taken from Mark's paper on XPF
+        matrix = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
+        phase_exp = 12
+        precision = 8
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        np.testing.assert_equal(xppauli.matrix, np.atleast_2d(matrix))
+        np.testing.assert_equal(xppauli._phase_exp, phase_exp)
+        np.testing.assert_equal(xppauli.precision, precision)
+
+
+@ddt
+class TestXPPauli(QiskitTestCase):
+    """Tests for XPPauli operator class."""
+
+    def test_precision_rescale(self):
+        """Test precision rescaling method."""
+        # Test case taken from Mark's paper on XPF
+        matrix = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
+        phase_exp = 12
+        precision = 8
+        new_precision = 2
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        rescaled_xppauli = xppauli.rescale_precision(new_precision=new_precision)
+        target_matrix = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=np.int64)
+        target_phase_exp = 3
+        target_xppauli = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=new_precision)
+        np.testing.assert_equal(target_xppauli.matrix, rescaled_xppauli.matrix)
+        np.testing.assert_equal(target_xppauli._phase_exp, rescaled_xppauli._phase_exp)
+        np.testing.assert_equal(target_xppauli.precision, rescaled_xppauli.precision)
+        
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -15,20 +15,10 @@
 """Tests for Pauli operator class."""
 
 import unittest
-import itertools as it
-from functools import lru_cache
 
 import numpy as np
-from ddt import ddt, data, unpack
-
-from qiskit import QuantumCircuit
-from qiskit.exceptions import QiskitError
+from ddt import ddt
 from qiskit.test import QiskitTestCase
-
-from qiskit.quantum_info.operators import Operator
-
-from qiskit_qec.operators.random import random_clifford, random_pauli, random_xppauli
-from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
 from qiskit_qec.operators.xp_pauli import XPPauli
 
 # TODO from qiskit_qec.utils.pauli_rep import split_pauli, cpxstr2exp
@@ -36,7 +26,7 @@ from qiskit_qec.operators.xp_pauli import XPPauli
 # from qiskit.quantum_info.operators.symplectic.pauli import _split_pauli_label, _phase_from_label
 
 
-@ddt 
+@ddt
 class TestXPPauliInit(QiskitTestCase):
     """Tests for XPPauli initialization."""
 
@@ -67,7 +57,9 @@ class TestXPPauli(QiskitTestCase):
         rescaled_xppauli = xppauli.rescale_precision(new_precision=new_precision)
         target_matrix = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=np.int64)
         target_phase_exp = 3
-        target_xppauli = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=new_precision)
+        target_xppauli = XPPauli(
+            data=target_matrix, phase_exp=target_phase_exp, precision=new_precision
+        )
         np.testing.assert_equal(target_xppauli.matrix, rescaled_xppauli.matrix)
         np.testing.assert_equal(target_xppauli._phase_exp, rescaled_xppauli._phase_exp)
         np.testing.assert_equal(target_xppauli.precision, rescaled_xppauli.precision)
@@ -143,17 +135,17 @@ class TestXPPauli(QiskitTestCase):
     def test_multiplication(self):
         """Test multiplication method."""
         # Test case taken from Mark's code.
-        a_matrix = np.array([0,1,0,0,2,0], dtype=np.int64)
+        a_matrix = np.array([0, 1, 0, 0, 2, 0], dtype=np.int64)
         a_phase_exp = 6
         a_precision = 4
         a = XPPauli(data=a_matrix, phase_exp=a_phase_exp, precision=a_precision)
-        b_matrix = np.array([1,1,1,3,3,0], dtype=np.int64)
+        b_matrix = np.array([1, 1, 1, 3, 3, 0], dtype=np.int64)
         b_phase_exp = 2
         b_precision = 4
         b = XPPauli(data=b_matrix, phase_exp=b_phase_exp, precision=b_precision)
         value = XPPauli.compose(a, b)
 
-        target_matrix = np.array([1,0,1,3,3,0], dtype=np.int64)
+        target_matrix = np.array([1, 0, 1, 3, 3, 0], dtype=np.int64)
         target_phase_exp = 6
         target_precision = 4
         target = XPPauli(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
@@ -161,7 +153,7 @@ class TestXPPauli(QiskitTestCase):
 
     def test_degree(self):
         """Test degree method."""
-        matrix = np.array([0,0,0,2,1,0], dtype=np.int64)
+        matrix = np.array([0, 0, 0, 2, 1, 0], dtype=np.int64)
         phase_exp = 2
         precision = 4
         xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
@@ -169,6 +161,7 @@ class TestXPPauli(QiskitTestCase):
 
         target = 4
         self.assertEqual(target, value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/operators/test_xp_pauli.py
+++ b/tests/operators/test_xp_pauli.py
@@ -79,9 +79,36 @@ class TestXPPauli(QiskitTestCase):
         precision = 8
         xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppauli.weight()
-        target = 2
+        target = 5
         self.assertEqual(value, target)
-        
+
+    def test_diagonal(self):
+        """Test is_diagonal method."""
+        # Test case taken from Mark's paper, Table 5.
+        matrix = np.array([0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3], dtype=np.int64)
+        phase_exp = 0
+        precision = 8
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli.is_diagonal()
+        target = np.array([True])
+        self.assertEqual(value, target)
+
+        # Test case taken from Mark's paper, Table 5.
+        matrix = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
+        phase_exp = 0
+        precision = 8
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli.is_diagonal()
+        target = np.array([True])
+        self.assertEqual(value, target)
+
+        matrix = np.array([0, 1, 0, 1, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
+        phase_exp = 12
+        precision = 8
+        xppauli = XPPauli(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli.is_diagonal()
+        target = np.array([False])
+        self.assertEqual(value, target)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -48,23 +48,19 @@ class TestXPPauliListOperator(QiskitTestCase):
         """Test precision rescaling method."""
         matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
         phase_exp1 = 12
-        precision1 = 8
-        new_precision1 = 2
-        matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 8], dtype=np.int64)
-        phase_exp2 = 6
-        precision2 = 10
-        new_precision2 = 5
+        matrix2 = np.array([1, 1, 0, 1, 0, 0, 0, 0, 0, 4, 0, 0, 0, 6], dtype=np.int64)
+        phase_exp2 = 8
+        precision = 8
+        new_precision = 4
         matrix = np.array([matrix1, matrix2])
         phase_exp = np.array([phase_exp1, phase_exp2])
-        precision = np.array([precision1, precision2])
-        new_precision = np.array([new_precision1, new_precision2])
 
         xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
         rescaled_xppaulilist = xppaulilist.rescale_precision(new_precision=new_precision)
-        target_matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=np.int64)
-        target_phase_exp1 = 3
-        target_matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4], dtype=np.int64)
-        target_phase_exp2 = 3
+        target_matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0], dtype=np.int64)
+        target_phase_exp1 = 6
+        target_matrix2 = np.array([1, 1, 0, 1, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3], dtype=np.int64)
+        target_phase_exp2 = 4
         target_matrix = np.array([target_matrix1, target_matrix2])
         target_phase_exp = np.array([target_phase_exp1, target_phase_exp2])
         target_xppaulilist = XPPauliList(

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -104,16 +104,30 @@ class TestXPPauliListOperator(QiskitTestCase):
     def test_antisymmetric_op(self):
         """Test antisymmetric_op method."""
 
-        matrix = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], [0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3, 7, 6, 3]], dtype=np.int64)
+        matrix = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3],
+                [0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3, 7, 6, 3],
+            ],
+            dtype=np.int64,
+        )
         phase_exp = np.array([0, 0])
         precision = 8
         xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppauli_list.antisymmetric_op()
 
-        target_matrix = np.array([[0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], [0, 0, 0, 0, 0, 0, 0, -3, -1, -2, -3, -7, -6, -3]], dtype=np.int64)
+        target_matrix = np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3],
+                [0, 0, 0, 0, 0, 0, 0, -3, -1, -2, -3, -7, -6, -3],
+            ],
+            dtype=np.int64,
+        )
         target_phase_exp = np.array([15, 25])
         target_precision = 8
-        target = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        target = XPPauliList(
+            data=target_matrix, phase_exp=target_phase_exp, precision=target_precision
+        )
         np.testing.assert_equal(target.matrix, value.matrix)
         np.testing.assert_equal(target._phase_exp, value._phase_exp)
         np.testing.assert_equal(target.precision, value.precision)
@@ -131,9 +145,11 @@ class TestXPPauliListOperator(QiskitTestCase):
         value = XPPauliList.compose(a, b)
 
         target_matrix = np.array([[1, 0, 1, 3, 3, 0], [1, 0, 1, 3, 3, 0]], dtype=np.int64)
-        target_phase_exp = np.array([6., 6.])
+        target_phase_exp = np.array([6, 6])
         target_precision = 4
-        target = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        target = XPPauliList(
+            data=target_matrix, phase_exp=target_phase_exp, precision=target_precision
+        )
         np.testing.assert_equal(target.matrix, value.matrix)
         np.testing.assert_equal(target._phase_exp, value._phase_exp)
         np.testing.assert_equal(target.precision, value.precision)
@@ -151,17 +167,31 @@ class TestXPPauliListOperator(QiskitTestCase):
 
     def test_power(self):
         """Test power method."""
-        matrix = np.array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1]], dtype=np.int64)
+        matrix = np.array(
+            [
+                [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1],
+                [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1],
+            ],
+            dtype=np.int64,
+        )
         phase_exp = np.array([12, 12])
         precision = 8
         n = 5
         xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppauli_list.power(n=n)
 
-        target_matrix = np.array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5]] ,dtype=np.int64)
+        target_matrix = np.array(
+            [
+                [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5],
+                [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5],
+            ],
+            dtype=np.int64,
+        )
         target_phase_exp = np.array([8, 8])
         target_precision = 8
-        target = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        target = XPPauliList(
+            data=target_matrix, phase_exp=target_phase_exp, precision=target_precision
+        )
         np.testing.assert_equal(target.matrix, value.matrix)
         np.testing.assert_equal(target._phase_exp, value._phase_exp)
         np.testing.assert_equal(target.precision, value.precision)

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -13,29 +13,10 @@
 """Tests for XPPauliList class."""
 
 import unittest
-
-
-import itertools as it
 import numpy as np
 from ddt import ddt
-
-from qiskit import QiskitError
-from qiskit.quantum_info.operators import (
-    Clifford,
-    Operator,
-    PauliTable,
-    StabilizerTable,
-)
-from qiskit.quantum_info.random import random_clifford, random_pauli_list
 from qiskit.test import QiskitTestCase
-
-# Note: In Qiskit tests below is just test
-
-from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
-from qiskit_qec.operators.xp_pauli import XPPauli
 from qiskit_qec.operators.xp_pauli_list import XPPauliList
-
-from tests import combine
 
 
 class TestXPPauliListInit(QiskitTestCase):
@@ -86,11 +67,12 @@ class TestXPPauliListOperator(QiskitTestCase):
         target_phase_exp2 = 3
         target_matrix = np.array([target_matrix1, target_matrix2])
         target_phase_exp = np.array([target_phase_exp1, target_phase_exp2])
-        target_xppaulilist = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=new_precision)
+        target_xppaulilist = XPPauliList(
+            data=target_matrix, phase_exp=target_phase_exp, precision=new_precision
+        )
         np.testing.assert_equal(target_xppaulilist.matrix, rescaled_xppaulilist.matrix)
         np.testing.assert_equal(target_xppaulilist._phase_exp, rescaled_xppaulilist._phase_exp)
         np.testing.assert_equal(target_xppaulilist.precision, rescaled_xppaulilist.precision)
-
 
     def test_weight(self):
         """Test weight method."""
@@ -103,7 +85,6 @@ class TestXPPauliListOperator(QiskitTestCase):
         matrix = np.array([matrix1, matrix2])
         phase_exp = np.array([phase_exp1, phase_exp2])
         precision = np.array([precision1, precision2])
-
         xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppaulilist.weight()
         target = np.array([5, 4])
@@ -125,7 +106,6 @@ class TestXPPauliListOperator(QiskitTestCase):
         matrix = np.array([matrix1, matrix2, matrix3])
         phase_exp = np.array([phase_exp1, phase_exp2, phase_exp3])
         precision = np.array([precision1, precision2, precision3])
-        
         xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
 
         value = xppaulilist.is_diagonal()

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -101,6 +101,23 @@ class TestXPPauliListOperator(QiskitTestCase):
         target = np.array([True, True, False])
         np.testing.assert_equal(target, value)
 
+    def test_antisymmetric_op(self):
+        """Test antisymmetric_op method."""
+
+        matrix = np.array([[0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 3, 3, 3], [0, 0, 0, 0, 0, 0, 0, 3, 1, 2, 3, 7, 6, 3]], dtype=np.int64)
+        phase_exp = np.array([0, 0])
+        precision = 8
+        xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli_list.antisymmetric_op()
+
+        target_matrix = np.array([[0, 0, 0, 0, 0, 0, 0, 0, -1, -2, -3, -3, -3, -3], [0, 0, 0, 0, 0, 0, 0, -3, -1, -2, -3, -7, -6, -3]], dtype=np.int64)
+        target_phase_exp = np.array([15, 25])
+        target_precision = 8
+        target = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        np.testing.assert_equal(target.matrix, value.matrix)
+        np.testing.assert_equal(target._phase_exp, value._phase_exp)
+        np.testing.assert_equal(target.precision, value.precision)
+
     def test_multiplication(self):
         """Test multiplication method."""
         a_matrix = np.array([[0, 1, 0, 0, 2, 0], [0, 1, 0, 0, 2, 0]], dtype=np.int64)
@@ -116,6 +133,34 @@ class TestXPPauliListOperator(QiskitTestCase):
         target_matrix = np.array([[1, 0, 1, 3, 3, 0], [1, 0, 1, 3, 3, 0]], dtype=np.int64)
         target_phase_exp = np.array([6., 6.])
         target_precision = 4
+        target = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        np.testing.assert_equal(target.matrix, value.matrix)
+        np.testing.assert_equal(target._phase_exp, value._phase_exp)
+        np.testing.assert_equal(target.precision, value.precision)
+
+    def test_degree(self):
+        """Test degree method."""
+        matrix = np.array([[0, 0, 0, 2, 1, 0], [0, 0, 0, 2, 1, 0]], dtype=np.int64)
+        phase_exp = np.array([2, 2])
+        precision = 4
+        xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli_list.degree()
+
+        target = np.array([4, 4])
+        np.testing.assert_equal(target, value)
+
+    def test_power(self):
+        """Test power method."""
+        matrix = np.array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1]], dtype=np.int64)
+        phase_exp = np.array([12, 12])
+        precision = 8
+        n = 5
+        xppauli_list = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppauli_list.power(n=n)
+
+        target_matrix = np.array([[1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5], [1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 5]] ,dtype=np.int64)
+        target_phase_exp = np.array([8, 8])
+        target_precision = 8
         target = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
         np.testing.assert_equal(target.matrix, value.matrix)
         np.testing.assert_equal(target._phase_exp, value._phase_exp)

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -25,15 +25,13 @@ class TestXPPauliListInit(QiskitTestCase):
     def test_array_init(self):
         """Test array initialization."""
         # Matrix array initialization
+        precision = 8
         matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
         phase_exp1 = 12
-        precision1 = 8
         matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 3, 0, 0, 0], dtype=np.int64)
         phase_exp2 = 2
-        precision2 = 4
         matrix = np.array([matrix1, matrix2])
         phase_exp = np.array([phase_exp1, phase_exp2])
-        precision = np.array([precision1, precision2])
         xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
         np.testing.assert_equal(xppaulilist.matrix, matrix)
         np.testing.assert_equal(xppaulilist._phase_exp, phase_exp)
@@ -72,15 +70,13 @@ class TestXPPauliListOperator(QiskitTestCase):
 
     def test_weight(self):
         """Test weight method."""
+        precision = 8
         matrix1 = np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64)
         phase_exp1 = 12
-        precision1 = 8
         matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4], dtype=np.int64)
         phase_exp2 = 3
-        precision2 = 5
         matrix = np.array([matrix1, matrix2])
         phase_exp = np.array([phase_exp1, phase_exp2])
-        precision = np.array([precision1, precision2])
         xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
         value = xppaulilist.weight()
         target = np.array([5, 4])
@@ -88,20 +84,17 @@ class TestXPPauliListOperator(QiskitTestCase):
 
     def test_diagonal(self):
         """Test is_diagonal method."""
+        precision = 8
         matrix1 = np.array([0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3], dtype=np.int64)
         phase_exp1 = 0
-        precision1 = 8
 
         matrix2 = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
         phase_exp2 = 0
-        precision2 = 5
 
         matrix3 = np.array([0, 1, 0, 1, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
         phase_exp3 = 12
-        precision3 = 8
         matrix = np.array([matrix1, matrix2, matrix3])
         phase_exp = np.array([phase_exp1, phase_exp2, phase_exp3])
-        precision = np.array([precision1, precision2, precision3])
         xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
 
         value = xppaulilist.is_diagonal()

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -62,7 +62,75 @@ class TestXPPauliListInit(QiskitTestCase):
 @ddt
 class TestXPPauliListOperator(QiskitTestCase):
     """Tests for XPPauliList base operator methods."""
-    pass
+
+    def test_precision_rescale(self):
+        """Test precision rescaling method."""
+        matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
+        phase_exp1 = 12
+        precision1 = 8
+        new_precision1 = 2
+        matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 8], dtype=np.int64)
+        phase_exp2 = 6
+        precision2 = 10
+        new_precision2 = 5
+        matrix = np.array([matrix1, matrix2])
+        phase_exp = np.array([phase_exp1, phase_exp2])
+        precision = np.array([precision1, precision2])
+        new_precision = np.array([new_precision1, new_precision2])
+
+        xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+        rescaled_xppaulilist = xppaulilist.rescale_precision(new_precision=new_precision)
+        target_matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0], dtype=np.int64)
+        target_phase_exp1 = 3
+        target_matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4], dtype=np.int64)
+        target_phase_exp2 = 3
+        target_matrix = np.array([target_matrix1, target_matrix2])
+        target_phase_exp = np.array([target_phase_exp1, target_phase_exp2])
+        target_xppaulilist = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=new_precision)
+        np.testing.assert_equal(target_xppaulilist.matrix, rescaled_xppaulilist.matrix)
+        np.testing.assert_equal(target_xppaulilist._phase_exp, rescaled_xppaulilist._phase_exp)
+        np.testing.assert_equal(target_xppaulilist.precision, rescaled_xppaulilist.precision)
+
+
+    def test_weight(self):
+        """Test weight method."""
+        matrix1 = np.array([1, 1, 1, 0, 0, 1, 0, 0, 3, 4, 0, 0, 0, 1], dtype=np.int64)
+        phase_exp1 = 12
+        precision1 = 8
+        matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 4], dtype=np.int64)
+        phase_exp2 = 3
+        precision2 = 5
+        matrix = np.array([matrix1, matrix2])
+        phase_exp = np.array([phase_exp1, phase_exp2])
+        precision = np.array([precision1, precision2])
+
+        xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+        value = xppaulilist.weight()
+        target = np.array([5, 4])
+        np.testing.assert_equal(target, value)
+
+    def test_diagonal(self):
+        """Test is_diagonal method."""
+        matrix1 = np.array([0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3], dtype=np.int64)
+        phase_exp1 = 0
+        precision1 = 8
+
+        matrix2 = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
+        phase_exp2 = 0
+        precision2 = 5
+
+        matrix3 = np.array([0, 1, 0, 1, 0, 0, 0, 0, 1, 3, 3, 3, 3, 3], dtype=np.int64)
+        phase_exp3 = 12
+        precision3 = 8
+        matrix = np.array([matrix1, matrix2, matrix3])
+        phase_exp = np.array([phase_exp1, phase_exp2, phase_exp3])
+        precision = np.array([precision1, precision2, precision3])
+        
+        xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+
+        value = xppaulilist.is_diagonal()
+        target = np.array([True, True, False])
+        np.testing.assert_equal(target, value)
 
 
 if __name__ == "__main__":

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -1,0 +1,69 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for XPPauliList class."""
+
+import unittest
+
+
+import itertools as it
+import numpy as np
+from ddt import ddt
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators import (
+    Clifford,
+    Operator,
+    PauliTable,
+    StabilizerTable,
+)
+from qiskit.quantum_info.random import random_clifford, random_pauli_list
+from qiskit.test import QiskitTestCase
+
+# Note: In Qiskit tests below is just test
+
+from qiskit_qec.operators.base_xp_pauli import BaseXPPauli
+from qiskit_qec.operators.xp_pauli import XPPauli
+from qiskit_qec.operators.xp_pauli_list import XPPauliList
+
+from tests import combine
+
+
+class TestXPPauliListInit(QiskitTestCase):
+    """Tests for XPPauliList initialization."""
+
+    def test_array_init(self):
+        """Test array initialization."""
+        # Matrix array initialization
+        matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
+        phase_exp1 = 12
+        precision1 = 8
+        matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 3, 0, 0, 0], dtype=np.int64)
+        phase_exp2 = 2
+        precision2 = 4
+        matrix = np.array([matrix1, matrix2])
+        phase_exp = np.array([phase_exp1, phase_exp2])
+        precision = np.array([precision1, precision2])
+        xppaulilist = XPPauliList(data=matrix, phase_exp=phase_exp, precision=precision)
+        np.testing.assert_equal(xppaulilist.matrix, matrix)
+        np.testing.assert_equal(xppaulilist._phase_exp, phase_exp)
+        np.testing.assert_equal(xppaulilist.precision, precision)
+
+
+@ddt
+class TestXPPauliListOperator(QiskitTestCase):
+    """Tests for XPPauliList base operator methods."""
+    pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/operators/test_xp_pauli_list.py
+++ b/tests/operators/test_xp_pauli_list.py
@@ -101,6 +101,26 @@ class TestXPPauliListOperator(QiskitTestCase):
         target = np.array([True, True, False])
         np.testing.assert_equal(target, value)
 
+    def test_multiplication(self):
+        """Test multiplication method."""
+        a_matrix = np.array([[0, 1, 0, 0, 2, 0], [0, 1, 0, 0, 2, 0]], dtype=np.int64)
+        a_phase_exp = np.array([6, 6])
+        a_precision = 4
+        a = XPPauliList(data=a_matrix, phase_exp=a_phase_exp, precision=a_precision)
+        b_matrix = np.array([[1, 1, 1, 3, 3, 0], [1, 1, 1, 3, 3, 0]], dtype=np.int64)
+        b_phase_exp = np.array([2, 2])
+        b_precision = 4
+        b = XPPauliList(data=b_matrix, phase_exp=b_phase_exp, precision=b_precision)
+        value = XPPauliList.compose(a, b)
+
+        target_matrix = np.array([[1, 0, 1, 3, 3, 0], [1, 0, 1, 3, 3, 0]], dtype=np.int64)
+        target_phase_exp = np.array([6., 6.])
+        target_precision = 4
+        target = XPPauliList(data=target_matrix, phase_exp=target_phase_exp, precision=target_precision)
+        np.testing.assert_equal(target.matrix, value.matrix)
+        np.testing.assert_equal(target._phase_exp, value._phase_exp)
+        np.testing.assert_equal(target.precision, value.precision)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Partial fix for #274 (part of #257 ). This PR contains an initial implementation of `XPPauli` and `XPPauliList` classes.

### Details and comments
This is an initial implementation of XP operator algebra (from [Mark Webster's package](https://github.com/m-webster/XPFpackage/blob/main/XPAlgebra.py) ) for `XPPauli` and `XPPauliList`. This is a work in progress.
- Added classes `XPPauli` and `XPPauliList` and associated test files.
- Functions implemented:
  - `random_xppauli` in operators/random.py
- Functionality implemented in `BaseXPPauli` (XP* are function names from Mark's code, name in brackets is the new name):
  - `XPSetN` (`rescale_precision`)
  - `XPDistance` (`weight`)
  - `XPisDiag` (`is_diagonal`)
  - `XPDegree` (`degree`)
  - `XPPower` (`power`)
  - `XPMul` (`compose`)
  - `XPRound` (`unique_vector_rep`)
  - `XPD` (`antisymmetric_op`)
- As part of refactoring, some helper functions in Mark's original code used by these functions have not been explicitly coded, they have been incorporated in the preceding functions. (These are `XPSetNSingle`, `XPSquare`, `XPdeg`).
- Added basic tests for `XPPauli` and `XPPauliList`. Some tests are yet to be added for `XPPauliList` for above implemented functions.
- Left TODOs for points to be discussed/yet to be implemented .

Highly appreciate your feedback!
