### PR TITLE
296 xp pauli rep (part of 257)

### DIFF
--- a/qiskit_qec/utils/pauli_rep.py
+++ b/qiskit_qec/utils/pauli_rep.py
@@ -256,7 +256,7 @@ def _is_pattern(string, pattern):
 
 
 def get_phase_encodings() -> List[str]:
-    """Returns the availble phase encodings
+    """Returns the available phase encodings
 
     Returns:
         encoding: List of available phase encodings
@@ -336,7 +336,7 @@ def split_pauli_enc(encoding: str) -> Tuple[str, str]:
     Returns:
         phase_enc, tensor_enc: phase encoding and tensor encoding
 
-    Exampes:
+    Examples:
         >>> encoding = "iXZ'
         >>> split_pauli_encoding(encoding)
         ('i', 'XZ')

--- a/qiskit_qec/utils/pauli_rep.py
+++ b/qiskit_qec/utils/pauli_rep.py
@@ -1238,7 +1238,7 @@ def exp2expstr(
     different encodings have a specific syntaxs.
 
     Args:
-        phase_exp: Phase encosings to convert to string representations
+        phase_exp: Phase encodings to convert to string representations
         input_encoding: Encoding of the input phase exponents
         same_type (optional): Scalar/Vector return flag. Defaults to True.
 

--- a/qiskit_qec/utils/pauli_rep.py
+++ b/qiskit_qec/utils/pauli_rep.py
@@ -102,13 +102,13 @@ PAULI_ENCODINGS_SPLIT = {
 # Different string syntax formats are available. The they are "product" syntax and
 # "index" syntax. "product" syntax represents a Pauli operator of the form
 # :math: $p * T_1 \otimes T_2 \otimes ... \otimes T_n$ as :math" $pT1T2T3...Tn$. See the
-# following exmaples:
+# following examples:
 #
 # -iX \otimes Y \otimes Z -> -iXYZ
 # X \otimes Y \otimes Z \otimes I \otimes I \otimes I  -> XYZII
 #
 # The index syntax only represents the non identity Paulis. Index syntax specifically
-# indiciates the index that the Pauli's are acting on. Following Qiskit's current internal
+# indicates the index that the Pauli's are acting on. Following Qiskit's current internal
 # indexing:
 #
 # -iX \otimes Y \otimes Z -> -iZ0Y1X2
@@ -328,7 +328,7 @@ def split_pauli_enc(encoding: str) -> Tuple[str, str]:
     """Splits the Pauli encoding into the phase and tensor encodings
 
     Args:
-        encoding: Pauli encpoding
+        encoding: Pauli encoding
 
     Raises:
         QiskitError: Encoding not valid
@@ -359,7 +359,7 @@ def _split_pauli_enc(encoding: str) -> Tuple[str, str]:
 
 
 def get_phase_enc(encoding: str) -> str:
-    """Returns the phase encodeing part of the Pauli encoding string
+    """Returns the phase encoding part of the Pauli encoding string
 
     Args:
         encoding: Pauli encoding string
@@ -372,7 +372,7 @@ def get_phase_enc(encoding: str) -> str:
 
 
 def get_tensor_enc(encoding: str) -> str:
-    """Returns the tensor encodeing part of the Pauli encoding string
+    """Returns the tensor encoding part of the Pauli encoding string
 
     Args:
         encoding: Pauli encoding string

--- a/qiskit_qec/utils/xp_pauli_rep.py
+++ b/qiskit_qec/utils/xp_pauli_rep.py
@@ -239,7 +239,7 @@ def _is_pattern(string, pattern):
 
 
 def get_phase_encodings() -> List[str]:
-    """Returns the availble phase encodings
+    """Returns the available phase encodings
 
     Returns:
         encoding: List of available phase encodings
@@ -304,7 +304,7 @@ def split_xp_pauli_enc(encoding: str) -> Tuple[str, str]:
     Returns:
         phase_enc, tensor_enc: phase encoding and tensor encoding
 
-    Exampes:
+    Examples:
         >>> encoding = "wXP"
         >>> split_xp_pauli_encoding(encoding)
         ('w', 'XP')
@@ -334,6 +334,11 @@ def get_phase_enc(encoding: str) -> str:
 
     Returns:
         phase_enc: phase encoding
+
+    Examples:
+        >>> encoding = "wXP"
+        >>> get_phase_enc(encoding)
+        'w'
     """
     phase_part, _ = split_xp_pauli_enc(encoding)
     return phase_part
@@ -346,7 +351,12 @@ def get_tensor_enc(encoding: str) -> str:
         encoding: XPPauli encoding string
 
     Returns:
-        phase_enc: tensor encoding
+        tensor_enc: tensor encoding
+
+    Examples:
+        >>> encoding = "wXP"
+        >>> get_tensor_enc(encoding)
+        'XP'
     """
     _, tensor_part = split_xp_pauli_enc(encoding)
     return tensor_part
@@ -765,12 +775,12 @@ def xp_symplectic2str(
     precision: int = None,
     input_encoding: str = INTERNAL_XP_PAULI_ENCODING,
     output_phase_encoding: str = None,
-    no_phase=False,
+    no_phase: bool = False,
     output_tensor_encoding: str = DEFAULT_EXTERNAL_TENSOR_ENCODING,
     syntax: str = INDEX_SYNTAX,
     qubit_order: str = "right-to-left",
     index_start: int = 0,
-    same_type=True,
+    same_type: bool = True,
     index_str="",
 ) -> Union[np.ndarray, str]:
     """Converts a symplectic matrix and phase to string representations
@@ -786,9 +796,7 @@ def xp_symplectic2str(
             A value of None will result in complex phases notation. Defaults
             to None.
         no_phase (optional): When set to True, no phase will appear no matter
-            what encoding is selected. So the symplectic matrix [1, 1] will produce
-            the operator Y in 'XZY' encoding but also (XZ) in the 'XZ' encoding which
-            are different operators if phases are considered.
+            what encoding is selected.
         output_tensor_encoding (optional): Encoding of XPPauli tensor
             (without phase). Defaults to DEFAULT_EXTERNAL_TENSOR_ENCODING.
         syntax (optional): Syntax of pauli tensor. Values are
@@ -809,7 +817,35 @@ def xp_symplectic2str(
         xp_pauli_str: XPPauli strings
 
     Examples:
-        TODO
+        >>> precision = 8
+        >>> matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
+        >>> phase_exp1 = 12
+        >>> matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 3, 0, 0, 0], dtype=np.int64)
+        >>> phase_exp2 = 2
+        >>> matrix = np.array([matrix1, matrix2])
+        >>> phase_exp = np.array([phase_exp1, phase_exp2])
+        >>> xp_symplectic2str(matrix, phase_exp, precision)
+        np.array(["XP8((w,12)(X(P,4))2(X)1(X)0)", "XP8((w,2)(P,3)3(X(P,2))2(X)1(X)0)"])
+
+        >>> xp_symplectic2str(matrix, phase_exp, precision, qubit_order="left-to-right")
+        np.array(["XP8((w,12)(X)0(X)1(X(P,4))2)", "XP8((w,2)(X)0(X)1(X(P,2))2(P,3)3)"])
+
+        >>> xp_symplectic2str(matrix, phase_exp, precision, syntax=XP_SYMPLECTIC_SYNTAX)
+        np.array(["XP8(12|1 1 1 0 0 0 0|0 0 4 0 0 0 0)", "XP8(2|1 1 1 0 0 0 0|0 0 2 3 0 0 0)"])
+
+        >>> xp_symplectic2str(matrix, phase_exp, precision, no_phase=True)
+        np.array(["XP8((X(P,4))2(X)1(X)0)", "XP8((P,3)3(X(P,2))2(X)1(X)0)"])
+
+        >>> xp_symplectic2str(matrix, phase_exp, precision, syntax=PRODUCT_SYNTAX)
+        np.array(["XP8((w,12)(I)(I)(I)(I)(X(P,4))(X)(X))", "XP8((w,2)(I)(I)(I)(P,3)(X(P,2))(X)(X))"])
+
+        >>> xp_symplectic2str(matrix, phase_exp, precision, syntax=LATEX_SYNTAX)
+        np.array(
+            [
+                "XP_{8}((w,12)(XP^{4})_{2}(X)_{1}(X)_{0})",
+                "XP_{8}((w,2)(P^{3})_{3}(XP^{2})_{2}(X)_{1}(X)_{0})",
+            ]
+        )
     """
     matrix = np.atleast_2d(matrix)
     num_qubits = matrix.shape[1] >> 1

--- a/tests/utils/test_xp_pauli_rep.py
+++ b/tests/utils/test_xp_pauli_rep.py
@@ -1,0 +1,47 @@
+"""Test xp pauli rep."""
+
+from unittest import TestCase
+import numpy as np
+
+from qiskit_qec.utils.xp_pauli_rep import (
+    xp_symplectic2str,
+    INDEX_SYNTAX,
+    PRODUCT_SYNTAX,
+    LATEX_SYNTAX,
+    XP_SYMPLECTIC_SYNTAX
+)
+
+class TestXPPauliRep(TestCase):
+    """Test xp pauli rep."""
+
+    def test_xp_symplectic2str(self):
+        """Tests xp_symplectic2str function."""
+
+        precision = 8
+        matrix1 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0], dtype=np.int64)
+        phase_exp1 = 12
+        matrix2 = np.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 2, 3, 0, 0, 0], dtype=np.int64)
+        phase_exp2 = 2
+        matrix = np.array([matrix1, matrix2])
+        phase_exp = np.array([phase_exp1, phase_exp2])
+
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision), np.array(['XP8((w,12)(XP4)2(X)1(X)0)', 'XP8((w,2)(P3)3(XP2)2(X)1(X)0)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, qubit_order="left-to-right"), np.array(['XP8((w,12)(X)0(X)1(XP4)2)', 'XP8((w,2)(X)0(X)1(XP2)2(P3)3)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=XP_SYMPLECTIC_SYNTAX), np.array(['XP8(12|1 1 1 0 0 0 0|0 0 4 0 0 0 0)', 'XP8(2|1 1 1 0 0 0 0|0 0 2 3 0 0 0)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, no_phase=True), np.array(['XP8((XP4)2(X)1(X)0)', 'XP8((P3)3(XP2)2(X)1(X)0)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=PRODUCT_SYNTAX), np.array(['XP8((w,12)(I)(I)(I)(I)(XP4)(X)(X))', 'XP8((w,2)(I)(I)(I)(P3)(XP2)(X)(X))']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=LATEX_SYNTAX), np.array(['XP_{8}((w,12)(XP^{4})_{2}(X)_{1}(X)_{0})', 'XP_{8}((w,2)(P^{3})_{3}(XP^{2})_{2}(X)_{1}(X)_{0})']))
+
+        # Tests conversion to unique vector format for different formats
+        precision = 4
+        matrix1 = np.array([1, 2, 3, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0], dtype=np.int64)
+        matrix2 = np.array([1, 2, 3, 0, 0, 0, 0, 0, 0, 2, 6, 0, 0, 0], dtype=np.int64)
+        matrix = np.array([matrix1, matrix2])
+
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision), np.array(['XP4((w,4)(XP)2(X)0)', 'XP4((w,2)(P2)3(XP2)2(X)0)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, qubit_order="left-to-right"), np.array(['XP4((w,4)(X)0(XP)2)', 'XP4((w,2)(X)0(XP2)2(P2)3)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=XP_SYMPLECTIC_SYNTAX), np.array(['XP4(4|1 0 1 0 0 0 0|0 0 1 0 0 0 0)', 'XP4(2|1 0 1 0 0 0 0|0 0 2 2 0 0 0)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, no_phase=True), np.array(['XP4((XP)2(X)0)', 'XP4((P2)3(XP2)2(X)0)']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=PRODUCT_SYNTAX), np.array(['XP4((w,4)(I)(I)(I)(I)(XP)(I)(X))', 'XP4((w,2)(I)(I)(I)(P2)(XP2)(I)(X))']))
+        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=LATEX_SYNTAX), np.array(['XP_{4}((w,4)(XP)_{2}(X)_{0})', 'XP_{4}((w,2)(P^{2})_{3}(XP^{2})_{2}(X)_{0})']))
+

--- a/tests/utils/test_xp_pauli_rep.py
+++ b/tests/utils/test_xp_pauli_rep.py
@@ -5,11 +5,11 @@ import numpy as np
 
 from qiskit_qec.utils.xp_pauli_rep import (
     xp_symplectic2str,
-    INDEX_SYNTAX,
     PRODUCT_SYNTAX,
     LATEX_SYNTAX,
-    XP_SYMPLECTIC_SYNTAX
+    XP_SYMPLECTIC_SYNTAX,
 )
+
 
 class TestXPPauliRep(TestCase):
     """Test xp pauli rep."""
@@ -25,12 +25,37 @@ class TestXPPauliRep(TestCase):
         matrix = np.array([matrix1, matrix2])
         phase_exp = np.array([phase_exp1, phase_exp2])
 
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision), np.array(['XP8((w,12)(XP4)2(X)1(X)0)', 'XP8((w,2)(P3)3(XP2)2(X)1(X)0)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, qubit_order="left-to-right"), np.array(['XP8((w,12)(X)0(X)1(XP4)2)', 'XP8((w,2)(X)0(X)1(XP2)2(P3)3)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=XP_SYMPLECTIC_SYNTAX), np.array(['XP8(12|1 1 1 0 0 0 0|0 0 4 0 0 0 0)', 'XP8(2|1 1 1 0 0 0 0|0 0 2 3 0 0 0)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, no_phase=True), np.array(['XP8((XP4)2(X)1(X)0)', 'XP8((P3)3(XP2)2(X)1(X)0)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=PRODUCT_SYNTAX), np.array(['XP8((w,12)(I)(I)(I)(I)(XP4)(X)(X))', 'XP8((w,2)(I)(I)(I)(P3)(XP2)(X)(X))']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=LATEX_SYNTAX), np.array(['XP_{8}((w,12)(XP^{4})_{2}(X)_{1}(X)_{0})', 'XP_{8}((w,2)(P^{3})_{3}(XP^{2})_{2}(X)_{1}(X)_{0})']))
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision),
+            np.array(["XP8((w,12)(X(P,4))2(X)1(X)0)", "XP8((w,2)(P,3)3(X(P,2))2(X)1(X)0)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, qubit_order="left-to-right"),
+            np.array(["XP8((w,12)(X)0(X)1(X(P,4))2)", "XP8((w,2)(X)0(X)1(X(P,2))2(P,3)3)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, syntax=XP_SYMPLECTIC_SYNTAX),
+            np.array(["XP8(12|1 1 1 0 0 0 0|0 0 4 0 0 0 0)", "XP8(2|1 1 1 0 0 0 0|0 0 2 3 0 0 0)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, no_phase=True),
+            np.array(["XP8((X(P,4))2(X)1(X)0)", "XP8((P,3)3(X(P,2))2(X)1(X)0)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, syntax=PRODUCT_SYNTAX),
+            np.array(
+                ["XP8((w,12)(I)(I)(I)(I)(X(P,4))(X)(X))", "XP8((w,2)(I)(I)(I)(P,3)(X(P,2))(X)(X))"]
+            ),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, syntax=LATEX_SYNTAX),
+            np.array(
+                [
+                    "XP_{8}((w,12)(XP^{4})_{2}(X)_{1}(X)_{0})",
+                    "XP_{8}((w,2)(P^{3})_{3}(XP^{2})_{2}(X)_{1}(X)_{0})",
+                ]
+            ),
+        )
 
         # Tests conversion to unique vector format for different formats
         precision = 4
@@ -38,10 +63,33 @@ class TestXPPauliRep(TestCase):
         matrix2 = np.array([1, 2, 3, 0, 0, 0, 0, 0, 0, 2, 6, 0, 0, 0], dtype=np.int64)
         matrix = np.array([matrix1, matrix2])
 
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision), np.array(['XP4((w,4)(XP)2(X)0)', 'XP4((w,2)(P2)3(XP2)2(X)0)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, qubit_order="left-to-right"), np.array(['XP4((w,4)(X)0(XP)2)', 'XP4((w,2)(X)0(XP2)2(P2)3)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=XP_SYMPLECTIC_SYNTAX), np.array(['XP4(4|1 0 1 0 0 0 0|0 0 1 0 0 0 0)', 'XP4(2|1 0 1 0 0 0 0|0 0 2 2 0 0 0)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, no_phase=True), np.array(['XP4((XP)2(X)0)', 'XP4((P2)3(XP2)2(X)0)']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=PRODUCT_SYNTAX), np.array(['XP4((w,4)(I)(I)(I)(I)(XP)(I)(X))', 'XP4((w,2)(I)(I)(I)(P2)(XP2)(I)(X))']))
-        np.testing.assert_equal(xp_symplectic2str(matrix, phase_exp, precision, syntax=LATEX_SYNTAX), np.array(['XP_{4}((w,4)(XP)_{2}(X)_{0})', 'XP_{4}((w,2)(P^{2})_{3}(XP^{2})_{2}(X)_{0})']))
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision),
+            np.array(["XP4((w,4)(XP)2(X)0)", "XP4((w,2)(P,2)3(X(P,2))2(X)0)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, qubit_order="left-to-right"),
+            np.array(["XP4((w,4)(X)0(XP)2)", "XP4((w,2)(X)0(X(P,2))2(P,2)3)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, syntax=XP_SYMPLECTIC_SYNTAX),
+            np.array(["XP4(4|1 0 1 0 0 0 0|0 0 1 0 0 0 0)", "XP4(2|1 0 1 0 0 0 0|0 0 2 2 0 0 0)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, no_phase=True),
+            np.array(["XP4((XP)2(X)0)", "XP4((P,2)3(X(P,2))2(X)0)"]),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, syntax=PRODUCT_SYNTAX),
+            np.array(
+                ["XP4((w,4)(I)(I)(I)(I)(XP)(I)(X))", "XP4((w,2)(I)(I)(I)(P,2)(X(P,2))(I)(X))"]
+            ),
+        )
+        np.testing.assert_equal(
+            xp_symplectic2str(matrix, phase_exp, precision, syntax=LATEX_SYNTAX),
+            np.array(
+                ["XP_{4}((w,4)(XP)_{2}(X)_{0})", "XP_{4}((w,2)(P^{2})_{3}(XP^{2})_{2}(X)_{0})"]
+            ),
+        )
 
+        # TODO add scalar return test (single operator, same_type=True/False)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Initial implementation of `xp_pauli_rep.py`. See issue #296 

### Details and comments
Initial implementation of `xp_symplectic2str` in `xp_pauli_rep.py`. Currently, as per the notation in the XP Formalism paper, there is one phase encoding implemented: `"w"` (representing $\omega$, the complex number $e^{i \pi/N}$), and one tensor encoding: `"XP"`. Also added a new syntax `XP_SYMPLECTIC_SYNTAX` for the $XP_N(p|x|z)$ notation used in the paper and the XPF package.

Broadly, the string representations currently implemented look like this (all 4 refer to the same operator):
- `INDEX_SYNTAX`: `'XP8((w,12)(X(P,4))2(X)1(X)0)'`
- `XP_SYMPLECTIC_SYNTAX`: `'XP8(12|1 1 1 0 0 0 0|0 0 4 0 0 0 0)'`
- `PRODUCT_SYNTAX`: `'XP8((w,12)(I)(I)(I)(I)(X(P,4))(X)(X))'`
- `LATEX_SYNTAX`: `'XP_{8}((w,12)(XP^{4})_{2}(X)_{1}(X)_{0})'`

The first two letters `XP` denote an XP operator; the number following this is the `precision`. `(w,12)` is the `"w"` phase encoding for $\omega^{12}$. An XP operator on 1 qubit is enclosed in `()` to prevent this ambiguity: the number inside the brackets (following the comma) is the exponent of the fractional Z rotation $P = diag(1,\omega^2)$, and the number outside the brackets is the index of the qubit on which the operator is acting.

Added tests in `tests/utils/test_xp_pauli_rep.py`.

At the moment, it does not make sense to implement any more encoding formats? According to the paper and the XPF package, more formats don't seem to have been used (except, perhaps, representing the phase as $e^{\pi i p/N}$ or $e^{2\pi i p/{2N}}$).
(If there are no more encoding formats to be added, then some code in `xp_pauli_rep.py` which was written based on encodings in `pauli_rep.py` but are not planned to be implemented for XPPaulis can be removed later, for example, multiple regex definitions, definitions related to `is` encoding, etc.)