### PR TITLE
update-integrate-stim

### DIFF
--- a/src/qiskit_qec/decoders/temp_graph_util.py
+++ b/src/qiskit_qec/decoders/temp_graph_util.py
@@ -1,7 +1,10 @@
 """Temporary module with methods for graphs."""
 import json
+import os
 import networkx as nx
 import rustworkx as rx
+
+from qiskit_qec.utils.decoding_graph_attributes import DecodingGraphEdge, DecodingGraphNode
 
 
 def ret2net(graph: rx.PyGraph):
@@ -9,12 +12,20 @@ def ret2net(graph: rx.PyGraph):
     nx_graph = nx.Graph()
     for j, node in enumerate(graph.nodes()):
         nx_graph.add_node(j)
-        for k, v in node.items():
-            nx.set_node_attributes(nx_graph, {j: v}, k)
+        for k, v in node:
+            if isinstance(v, dict):
+                for _k, _v in v.items():
+                    nx.set_node_attributes(nx_graph, {j: _v}, _k)
+            else:
+                nx.set_node_attributes(nx_graph, {j: v}, k)
     for j, (n0, n1) in enumerate(graph.edge_list()):
         nx_graph.add_edge(n0, n1)
-        for k, v in graph.edges()[j].items():
-            nx.set_edge_attributes(nx_graph, {(n0, n1): v}, k)
+        for k, v in graph.edges()[j]:
+            if isinstance(v, dict):
+                for _k, _v in v.items():
+                    nx.set_edge_attributes(nx_graph, {(n0, n1): _v}, _k)
+            else:
+                nx.set_edge_attributes(nx_graph, {(n0, n1): v}, k)
     return nx_graph
 
 
@@ -25,3 +36,42 @@ def write_graph_to_json(graph: rx.PyGraph, filename: str):
         from_ret = ret2net(graph)
         json.dump(nx.node_link_data(from_ret), fp, indent=4, default=str)
     fp.close()
+
+
+def get_cached_decoding_graph(path):
+    """
+    Returns graph cached in file at path "file" using cache_graph method.
+    """
+    if os.path.isfile(path) and not os.stat(path) == 0:
+        with open(path, "r+", encoding="utf-8") as file:
+            json_data = json.loads(file.read())
+            net_graph = nx.node_link_graph(json_data)
+        ret_graph = rx.networkx_converter(net_graph, keep_attributes=True)
+        for node_index, node in zip(ret_graph.node_indices(), ret_graph.nodes()):
+            del node["__networkx_node__"]
+            qubits = node.pop("qubits")
+            time = node.pop("time")
+            index = node.pop("index")
+            is_boundary = node.pop("is_boundary")
+            properties = node.copy()
+            node = DecodingGraphNode(is_boundary=is_boundary, time=time, index=index, qubits=qubits)
+            node.properties = properties
+            ret_graph[node_index] = node
+        for edge_index, edge in zip(ret_graph.edge_indices(), ret_graph.edges()):
+            weight = edge.pop("weight")
+            qubits = edge.pop("qubits")
+            properties = edge.copy()
+            edge = DecodingGraphEdge(weight=weight, qubits=qubits)
+            edge.properties = properties
+            ret_graph.update_edge_by_index(edge_index, edge)
+        return ret_graph
+    return None
+
+
+def cache_decoding_graph(graph, path):
+    """
+    Cache rustworkx PyGraph to file at path.
+    """
+    net_graph = ret2net(graph)
+    with open(path, "w+", encoding="utf-8") as file:
+        json.dump(nx.node_link_data(net_graph), file)

--- a/src/qiskit_qec/utils/__init__.py
+++ b/src/qiskit_qec/utils/__init__.py
@@ -31,4 +31,4 @@ Utils module classes and functions
 """
 
 from . import indexer, pauli_rep, visualizations
-from .decodoku import Decodoku
+from .decoding_graph_attributes import DecodingGraphNode, DecodingGraphEdge

--- a/src/qiskit_qec/utils/decoding_graph_attributes.py
+++ b/src/qiskit_qec/utils/decoding_graph_attributes.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=invalid-name
+
+"""
+Graph used as the basis of decoders.
+"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from qiskit_qec.exceptions import QiskitQECError
+
+
+class DecodingGraphNode:
+    """
+    Class to describe DecodingGraph nodes.
+
+    Attributes:
+     - is_boundary (bool): whether or not the node is a boundary node.
+     - time (int): what syndrome node the node corrsponds to. Doesn't
+        need to be set if it's a boundary node.
+     - qubits (List[int]): List of indices which are stabilized by
+        this ancilla.
+     - index (int): Unique index in measurement round.
+     - properties (Dict[str, Any]): Decoder/code specific attributes.
+        Are not considered when comparing nodes.
+    """
+
+    def __init__(self, index: int, qubits: List[int] = None, is_boundary=False, time=None) -> None:
+        if not is_boundary and time is None:
+            raise QiskitQECError(
+                "DecodingGraph node must either have a time or be a boundary node."
+            )
+
+        self.is_boundary: bool = is_boundary
+        self.time: Optional[int] = time if not is_boundary else None
+        self.qubits: List[int] = qubits if qubits else []
+        self.index: int = index
+        self.properties: Dict[str, Any] = {}
+
+    def __eq__(self, rhs):
+        if not isinstance(rhs, DecodingGraphNode):
+            return NotImplemented
+
+        result = (
+            self.index == rhs.index
+            and set(self.qubits) == set(rhs.qubits)
+            and self.is_boundary == rhs.is_boundary
+        )
+        if not self.is_boundary:
+            result = result and self.time == rhs.time
+        return result
+
+    def __hash__(self) -> int:
+        return hash(repr(self))
+
+    def __iter__(self):
+        for attr, value in self.__dict__.items():
+            yield attr, value
+
+
+@dataclass
+class DecodingGraphEdge:
+    """
+    Class to describe DecodingGraph edges.
+
+    Attributes:
+     - qubits (List[int]): List of indices of code qubits that correspond to this edge.
+     - weight (float): Weight of the edge.
+     - properties (Dict[str, Any]): Decoder/code specific attributes.
+        Are not considered when comparing edges.
+    """
+
+    qubits: List[int]
+    weight: float
+    # TODO: Should code/decoder specific properties be accounted for when comparing edges
+    properties: Dict[str, Any] = field(default_factory=dict)
+
+    def __eq__(self, rhs) -> bool:
+        if not isinstance(rhs, DecodingGraphNode):
+            return NotImplemented
+
+        return set(self.qubits) == set(rhs.qubits) and self.weight == rhs.weight
+
+    def __hash__(self) -> int:
+        return hash(repr(self))
+
+    def __iter__(self):
+        for attr, value in self.__dict__.items():
+            yield attr, value

--- a/src/qiskit_qec/utils/decodoku.py
+++ b/src/qiskit_qec/utils/decodoku.py
@@ -58,7 +58,6 @@ class Decodoku:
         self._generate_graph()
 
     def _generate_syndrome(self):
-
         syndrome = {}
         for x in range(self.size):
             for y in range(self.size):
@@ -69,7 +68,6 @@ class Decodoku:
         else:
             error_num = poisson(self.p * 2 * self.size**2)
             for _ in range(error_num):
-
                 x0 = choice(range(self.size))
                 y0 = choice(range(self.size))
 
@@ -317,7 +315,6 @@ class Decodoku:
         self.boundary_errors = parity
 
     def _generate_graph(self):
-
         dg = DecodingGraph(None)
 
         d = self.size - 1
@@ -334,7 +331,7 @@ class Decodoku:
                 {
                     "y": 0,
                     "x": (d - 1) * (elem == 1) - 1 * (elem == 0),
-                    "element": elem,
+                    "index": elem,
                     "is_boundary": True,
                 }
             )
@@ -343,10 +340,10 @@ class Decodoku:
         nodes = dg.graph.nodes()
         # connect edges to boundary nodes
         for y in range(self.size):
-            n0 = nodes.index({"y": 0, "x": -1, "element": 0, "is_boundary": True})
+            n0 = nodes.index({"y": 0, "x": -1, "index": 0, "is_boundary": True})
             n1 = nodes.index({"y": y, "x": 0, "is_boundary": False})
             dg.graph.add_edge(n0, n1, None)
-            n0 = nodes.index({"y": 0, "x": d - 1, "element": 1, "is_boundary": True})
+            n0 = nodes.index({"y": 0, "x": d - 1, "index": 1, "is_boundary": True})
             n1 = nodes.index({"y": y, "x": d - 2, "is_boundary": False})
             dg.graph.add_edge(n0, n1, None)
         # connect bulk nodes with space-like edges
@@ -373,7 +370,6 @@ class Decodoku:
         self._update_graph(original=False)
 
     def _update_graph(self, original=False):
-
         for node in self.decoding_graph.graph.nodes():
             node["highlighted"] = False
             if self.k != 2:
@@ -403,7 +399,6 @@ class Decodoku:
         self.node_color = highlighted_color
 
     def _start(self, engine):
-
         d = self.k
         syndrome = self.syndrome
 
@@ -439,7 +434,6 @@ class Decodoku:
 
     # this is the function that does everything
     def _next_frame(self, engine):
-
         d = self.k
         syndrome = self.syndrome
 
@@ -542,7 +536,7 @@ class Decodoku:
 
         def get_label(node):
             if node["is_boundary"] and parity:
-                return str(parity[node["element"]])
+                return str(parity[node["index"]])
             elif node["highlighted"] and "value" in node and self.k != 2:
                 return str(node["value"])
             else:

--- a/test/code_circuits/test_surface_codes.py
+++ b/test/code_circuits/test_surface_codes.py
@@ -19,9 +19,10 @@
 import unittest
 
 from qiskit_qec.circuits.surface_code import SurfaceCodeCircuit
+from qiskit_qec.utils import DecodingGraphNode
 
 
-class TestRepCodes(unittest.TestCase):
+class TestSurfaceCodes(unittest.TestCase):
     """Test the surface code circuits."""
 
     def test_string2nodes(self):
@@ -41,39 +42,87 @@ class TestRepCodes(unittest.TestCase):
         test_nodes["x"] = [
             [],
             [
-                {"time": 1, "qubits": [0, 1, 3, 4], "is_boundary": False, "element": 1},
-                {"time": 1, "qubits": [4, 5, 7, 8], "is_boundary": False, "element": 2},
+                DecodingGraphNode(
+                    time=1,
+                    qubits=[0, 1, 3, 4],
+                    index=1,
+                ),
+                DecodingGraphNode(
+                    time=1,
+                    qubits=[4, 5, 7, 8],
+                    index=2,
+                ),
             ],
             [
-                {"time": 0, "qubits": [0, 1, 3, 4], "is_boundary": False, "element": 1},
-                {"time": 0, "qubits": [4, 5, 7, 8], "is_boundary": False, "element": 2},
+                DecodingGraphNode(
+                    time=0,
+                    qubits=[0, 1, 3, 4],
+                    index=1,
+                ),
+                DecodingGraphNode(
+                    time=0,
+                    qubits=[4, 5, 7, 8],
+                    index=2,
+                ),
             ],
             [
-                {"time": 0, "qubits": [0, 3, 6], "is_boundary": True, "element": 0},
-                {"time": 1, "qubits": [0, 1, 3, 4], "is_boundary": False, "element": 1},
+                DecodingGraphNode(
+                    is_boundary=True,
+                    qubits=[0, 3, 6],
+                    index=0,
+                ),
+                DecodingGraphNode(
+                    time=1,
+                    qubits=[0, 1, 3, 4],
+                    index=1,
+                ),
             ],
             [
-                {"time": 0, "qubits": [2, 5, 8], "is_boundary": True, "element": 1},
-                {"time": 1, "qubits": [4, 5, 7, 8], "is_boundary": False, "element": 2},
+                DecodingGraphNode(
+                    is_boundary=True,
+                    qubits=[2, 5, 8],
+                    index=1,
+                ),
+                DecodingGraphNode(
+                    time=1,
+                    qubits=[4, 5, 7, 8],
+                    index=2,
+                ),
             ],
         ]
         test_nodes["z"] = [
             [],
             [
-                {"time": 0, "qubits": [1, 4, 2, 5], "is_boundary": False, "element": 1},
-                {"time": 0, "qubits": [3, 6, 4, 7], "is_boundary": False, "element": 2},
+                DecodingGraphNode(
+                    time=0,
+                    qubits=[1, 4, 2, 5],
+                    index=1,
+                ),
+                DecodingGraphNode(
+                    time=0,
+                    qubits=[3, 6, 4, 7],
+                    index=2,
+                ),
             ],
             [
-                {"time": 1, "qubits": [1, 4, 2, 5], "is_boundary": False, "element": 1},
-                {"time": 1, "qubits": [3, 6, 4, 7], "is_boundary": False, "element": 2},
+                DecodingGraphNode(
+                    time=1,
+                    qubits=[1, 4, 2, 5],
+                    index=1,
+                ),
+                DecodingGraphNode(
+                    time=1,
+                    qubits=[3, 6, 4, 7],
+                    index=2,
+                ),
             ],
             [
-                {"time": 0, "qubits": [0, 1, 2], "is_boundary": True, "element": 0},
-                {"time": 1, "qubits": [0, 3], "is_boundary": False, "element": 0},
+                DecodingGraphNode(is_boundary=True, qubits=[0, 1, 2], index=0),
+                DecodingGraphNode(time=1, qubits=[0, 3], index=0),
             ],
             [
-                {"time": 0, "qubits": [8, 7, 6], "is_boundary": True, "element": 1},
-                {"time": 1, "qubits": [5, 8], "is_boundary": False, "element": 3},
+                DecodingGraphNode(is_boundary=True, qubits=[8, 7, 6], index=1),
+                DecodingGraphNode(time=1, qubits=[5, 8], index=3),
             ],
         ]
 
@@ -81,8 +130,9 @@ class TestRepCodes(unittest.TestCase):
             code = SurfaceCodeCircuit(3, 1, basis=basis)
             for t, string in enumerate(test_string):
                 nodes = test_nodes[basis][t]
+                generated_nodes = code.string2nodes(string)
                 self.assertTrue(
-                    code.string2nodes(string) == nodes,
+                    generated_nodes == nodes,
                     "Incorrect nodes for basis = " + basis + " for string = " + string + ".",
                 )
 
@@ -99,91 +149,91 @@ class TestRepCodes(unittest.TestCase):
         valid = valid and code.check_nodes(nodes) == (True, [], 0)
         # on one side
         nodes = [
-            {"time": 0, "qubits": [0, 1, 2], "is_boundary": True, "element": 0},
-            {"time": 3, "qubits": [0, 3], "is_boundary": False, "element": 0},
+            DecodingGraphNode(qubits=[0, 1, 2], is_boundary=True, index=0),
+            DecodingGraphNode(time=3, qubits=[0, 3], index=0),
         ]
         valid = valid and code.check_nodes(nodes) == (True, [], 1.0)
-        nodes = [{"time": 3, "qubits": [0, 3], "is_boundary": False, "element": 0}]
+        nodes = [DecodingGraphNode(time=3, qubits=[0, 3], index=0)]
         valid = valid and code.check_nodes(nodes) == (
             True,
-            [{"time": 0, "qubits": [0, 1, 2], "is_boundary": True, "element": 0}],
+            [DecodingGraphNode(time=0, qubits=[0, 1, 2], is_boundary=True, index=0)],
             1.0,
         )
         # and the other
         nodes = [
-            {"time": 0, "qubits": [8, 7, 6], "is_boundary": True, "element": 1},
-            {"time": 3, "qubits": [5, 8], "is_boundary": False, "element": 3},
+            DecodingGraphNode(time=0, qubits=[8, 7, 6], is_boundary=True, index=1),
+            DecodingGraphNode(time=3, qubits=[5, 8], index=3),
         ]
         valid = valid and code.check_nodes(nodes) == (True, [], 1.0)
-        nodes = [{"time": 3, "qubits": [5, 8], "is_boundary": False, "element": 3}]
+        nodes = [DecodingGraphNode(time=3, qubits=[5, 8], index=3)]
         valid = valid and code.check_nodes(nodes) == (
             True,
-            [{"time": 0, "qubits": [8, 7, 6], "is_boundary": True, "element": 1}],
+            [DecodingGraphNode(time=0, qubits=[8, 7, 6], is_boundary=True, index=1)],
             1.0,
         )
         # and in the middle
         nodes = [
-            {"time": 3, "qubits": [1, 4, 2, 5], "is_boundary": False, "element": 1},
-            {"time": 3, "qubits": [3, 6, 4, 7], "is_boundary": False, "element": 2},
+            DecodingGraphNode(time=3, qubits=[1, 4, 2, 5], index=1),
+            DecodingGraphNode(time=3, qubits=[3, 6, 4, 7], index=2),
         ]
         valid = valid and code.check_nodes(nodes) == (True, [], 1)
-        nodes = [{"time": 3, "qubits": [3, 6, 4, 7], "is_boundary": False, "element": 2}]
+        nodes = [DecodingGraphNode(time=3, qubits=[3, 6, 4, 7], index=2)]
         valid = valid and code.check_nodes(nodes) == (
             True,
-            [{"time": 0, "qubits": [8, 7, 6], "is_boundary": True, "element": 1}],
+            [DecodingGraphNode(qubits=[8, 7, 6], is_boundary=True, index=1)],
             1.0,
         )
 
         # basis = 'x'
         code = SurfaceCodeCircuit(3, 3, basis="x")
         nodes = [
-            {"time": 3, "qubits": [0, 1, 3, 4], "is_boundary": False, "element": 1},
-            {"time": 3, "qubits": [4, 5, 7, 8], "is_boundary": False, "element": 2},
+            DecodingGraphNode(time=3, qubits=[0, 1, 3, 4], index=1),
+            DecodingGraphNode(time=3, qubits=[4, 5, 7, 8], index=2),
         ]
         valid = valid and code.check_nodes(nodes) == (True, [], 1)
-        nodes = [{"time": 3, "qubits": [4, 5, 7, 8], "is_boundary": False, "element": 2}]
+        nodes = [DecodingGraphNode(time=3, qubits=[4, 5, 7, 8], index=2)]
         valid = valid and code.check_nodes(nodes) == (
             True,
-            [{"time": 0, "qubits": [2, 5, 8], "is_boundary": True, "element": 1}],
+            [DecodingGraphNode(qubits=[2, 5, 8], is_boundary=True, index=1)],
             1.0,
         )
 
         # large d
         code = SurfaceCodeCircuit(5, 3, basis="z")
         nodes = [
-            {"time": 3, "qubits": [7, 12, 8, 13], "is_boundary": False, "element": 4},
-            {"time": 3, "qubits": [11, 16, 12, 17], "is_boundary": False, "element": 7},
+            DecodingGraphNode(time=3, qubits=[7, 12, 8, 13], index=4),
+            DecodingGraphNode(time=3, qubits=[11, 16, 12, 17], index=7),
         ]
         valid = valid and code.check_nodes(nodes) == (True, [], 1)
-        nodes = [{"time": 3, "qubits": [11, 16, 12, 17], "is_boundary": False, "element": 7}]
+        nodes = [DecodingGraphNode(time=3, qubits=[11, 16, 12, 17], index=7)]
         valid = valid and code.check_nodes(nodes) == (
             True,
-            [{"time": 0, "qubits": [24, 23, 22, 21, 20], "is_boundary": True, "element": 1}],
+            [DecodingGraphNode(qubits=[24, 23, 22, 21, 20], is_boundary=True, index=1)],
             2.0,
         )
 
         # wrong boundary
         nodes = [
-            {"time": 3, "qubits": [7, 12, 8, 13], "is_boundary": False, "element": 4},
-            {"time": 0, "qubits": [24, 23, 22, 21, 20], "is_boundary": True, "element": 1},
+            DecodingGraphNode(time=3, qubits=[7, 12, 8, 13], index=4),
+            DecodingGraphNode(qubits=[24, 23, 22, 21, 20], is_boundary=True, index=1),
         ]
         valid = valid and code.check_nodes(nodes) == (
             False,
-            [{"time": 0, "qubits": [0, 1, 2, 3, 4], "is_boundary": True, "element": 0}],
+            [DecodingGraphNode(qubits=[0, 1, 2, 3, 4], is_boundary=True, index=0)],
             2,
         )
         # extra boundary
         nodes = [
-            {"time": 3, "qubits": [7, 12, 8, 13], "is_boundary": False, "element": 4},
-            {"time": 3, "qubits": [11, 16, 12, 17], "is_boundary": False, "element": 7},
-            {"time": 0, "qubits": [24, 23, 22, 21, 20], "is_boundary": True, "element": 1},
+            DecodingGraphNode(time=3, qubits=[7, 12, 8, 13], index=4),
+            DecodingGraphNode(time=3, qubits=[11, 16, 12, 17], index=7),
+            DecodingGraphNode(qubits=[24, 23, 22, 21, 20], is_boundary=True, index=1),
         ]
         valid = valid and code.check_nodes(nodes) == (False, [], 0)
         # ignoring extra
         nodes = [
-            {"time": 3, "qubits": [7, 12, 8, 13], "is_boundary": False, "element": 4},
-            {"time": 3, "qubits": [11, 16, 12, 17], "is_boundary": False, "element": 7},
-            {"time": 0, "qubits": [24, 23, 22, 21, 20], "is_boundary": True, "element": 1},
+            DecodingGraphNode(time=3, qubits=[7, 12, 8, 13], index=4),
+            DecodingGraphNode(time=3, qubits=[11, 16, 12, 17], index=7),
+            DecodingGraphNode(qubits=[24, 23, 22, 21, 20], is_boundary=True, index=1),
         ]
         valid = valid and code.check_nodes(nodes, ignore_extra_boundary=True) == (True, [], 1)
 

--- a/test/matching/test_circuitmatcher.py
+++ b/test/matching/test_circuitmatcher.py
@@ -268,7 +268,7 @@ class TestCircuitMatcher(unittest.TestCase):
             corrected_outcomes = dec.process(outcome)
             fail = temp_syndrome(corrected_outcomes, self.z_logical)
             failures += fail[0]
-        self.assertEqual(failures, 128)
+        self.assertEqual(failures, 140)
 
     def test_error_pairs_uniform(self):
         """Test the case with two faults using rustworkx."""

--- a/test/matching/test_pymatchingmatcher.py
+++ b/test/matching/test_pymatchingmatcher.py
@@ -4,6 +4,7 @@ import unittest
 from typing import Dict, Tuple
 import rustworkx as rx
 from qiskit_qec.decoders.pymatching_matcher import PyMatchingMatcher
+from qiskit_qec.utils import DecodingGraphNode, DecodingGraphEdge
 
 
 class TestPyMatchingMatcher(unittest.TestCase):
@@ -18,14 +19,22 @@ class TestPyMatchingMatcher(unittest.TestCase):
         graph = rx.PyGraph(multigraph=False)
         idxmap = {}
         for i, q in enumerate([[0, 1], [1, 2], [2, 3], [3, 4]]):
-            node = {"time": 0, "qubits": q, "highlighted": False}
+            node = DecodingGraphNode(time=0, qubits=q, index=i)
+            node.properties["highlighted"] = False
             graph.add_node(node)
             idxmap[(0, tuple(q))] = i
         node = {"time": 0, "qubits": [], "highlighted": False, "is_boundary": True}
+        node = DecodingGraphNode(is_boundary=True, qubits=[], index=0)
+        node.properties["highlighted"] = False
         graph.add_node(node)
         idxmap[(0, tuple([]))] = 4
         for dat in [[[0], 0, 4], [[1], 0, 1], [[2], 1, 2], [[3], 2, 3], [[4], 3, 4]]:
-            edge = {"qubits": dat[0], "measurement_error": False, "weight": 1, "highlighted": False}
+            edge = DecodingGraphEdge(
+                qubits=dat[0],
+                weight=1,
+            )
+            edge.properties["measurement_error"] = False
+            edge.properties["highlighted"] = False
             graph.add_edge(dat[1], dat[2], edge)
         return graph, idxmap
 

--- a/test/matching/test_retworkxmatcher.py
+++ b/test/matching/test_retworkxmatcher.py
@@ -4,6 +4,7 @@ import unittest
 from typing import Dict, Tuple
 import rustworkx as rx
 from qiskit_qec.decoders.rustworkx_matcher import RustworkxMatcher
+from qiskit_qec.utils import DecodingGraphNode, DecodingGraphEdge
 
 
 class TestRustworkxMatcher(unittest.TestCase):
@@ -17,15 +18,20 @@ class TestRustworkxMatcher(unittest.TestCase):
         """
         graph = rx.PyGraph(multigraph=False)
         idxmap = {}
-        for i, q in enumerate([[0, 1], [1, 2], [2, 3], [3, 4]]):
-            node = {"time": 0, "qubits": q, "highlighted": False}
+        basic_config = [[0, 1], [1, 2], [2, 3], [3, 4]]
+        for i, q in enumerate(basic_config):
+            node = DecodingGraphNode(time=0, qubits=q, index=i)
+            node.properties["highlighted"] = False
             graph.add_node(node)
             idxmap[(0, tuple(q))] = i
-        node = {"time": 0, "qubits": [], "highlighted": False}
+        node = DecodingGraphNode(time=0, qubits=[], index=len(basic_config) + 1)
+        node.properties["highlighted"] = False
         graph.add_node(node)
         idxmap[(0, tuple([]))] = 4
         for dat in [[[0], 0, 4], [[1], 0, 1], [[2], 1, 2], [[3], 2, 3], [[4], 3, 4]]:
-            edge = {"qubits": dat[0], "measurement_error": False, "weight": 1, "highlighted": False}
+            edge = DecodingGraphEdge(qubits=dat[0], weight=1)
+            edge.properties["measurement_error"] = False
+            edge.properties["highlighted"] = False
             graph.add_edge(dat[1], dat[2], edge)
         return graph, idxmap
 
@@ -58,17 +64,17 @@ class TestRustworkxMatcher(unittest.TestCase):
         self.rxm.preprocess(graph)
         highlighted = [(0, (0, 1)), (0, (1, 2)), (0, (3, 4)), (0, ())]  # must be even
         self.rxm.find_errors(graph, idxmap, highlighted)
-        self.assertEqual(self.rxm.annotated_graph[0]["highlighted"], True)
-        self.assertEqual(self.rxm.annotated_graph[1]["highlighted"], True)
-        self.assertEqual(self.rxm.annotated_graph[2]["highlighted"], False)
-        self.assertEqual(self.rxm.annotated_graph[3]["highlighted"], True)
-        self.assertEqual(self.rxm.annotated_graph[4]["highlighted"], True)
+        self.assertEqual(self.rxm.annotated_graph[0].properties["highlighted"], True)
+        self.assertEqual(self.rxm.annotated_graph[1].properties["highlighted"], True)
+        self.assertEqual(self.rxm.annotated_graph[2].properties["highlighted"], False)
+        self.assertEqual(self.rxm.annotated_graph[3].properties["highlighted"], True)
+        self.assertEqual(self.rxm.annotated_graph[4].properties["highlighted"], True)
         eim = self.rxm.annotated_graph.edge_index_map()
-        self.assertEqual(eim[0][2]["highlighted"], False)
-        self.assertEqual(eim[1][2]["highlighted"], True)
-        self.assertEqual(eim[2][2]["highlighted"], False)
-        self.assertEqual(eim[3][2]["highlighted"], False)
-        self.assertEqual(eim[4][2]["highlighted"], True)
+        self.assertEqual(eim[0][2].properties["highlighted"], False)
+        self.assertEqual(eim[1][2].properties["highlighted"], True)
+        self.assertEqual(eim[2][2].properties["highlighted"], False)
+        self.assertEqual(eim[3][2].properties["highlighted"], False)
+        self.assertEqual(eim[4][2].properties["highlighted"], True)
 
 
 if __name__ == "__main__":

--- a/test/utils/test_decodoku.py
+++ b/test/utils/test_decodoku.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from qiskit_qec.utils import Decodoku
+from qiskit_qec.utils.decodoku import Decodoku
 
 
 class TestDecodoku(unittest.TestCase):


### PR DESCRIPTION
* make hdrg decoder more universal

* fix typos

* Add first version of Node and Edge types

Tests won't run because of circular import issue

* create CodeCircuit class

* add more detail to init

* add default is_cluster_neutral

* Add new DecodinGraph Node type support everywhere

This patch adds support for the new Node everywhere, such that it passes all tests. It also moves DecodingGraph to the analysis module due to a circular dependency issue.

* Move new Node and Edge types to utils and rename

And lint and black

* Move new Node and Edge types to utils and rename

And lint and black

* create CodeCircuit class (#329)

* create CodeCircuit class

* add more detail to init

* add default is_cluster_neutral

* Lint and Black

* Update decoding graph caching to support new node tzpes

* Added Cmake as a requirement (#336)

* element->index in decodoku

* DecodingGraph, Tests, ARC: Fix things for PR

* DecodingGraph, Tests, ARC: Fix things for PR

* remove unused import

* use all logicals

* Added Cmake as a requirement (#336) (#345)



* DecodingGraph: Add optional graph attribute for cached graphs

* Update hdrg_decoders.py

* Update hdrg_decoders.py

---------

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

