### PR TITLE
choose edge flip probabilities to saturate at 1/2

### DIFF
--- a/src/qiskit_qec/decoders/circuit_matching_decoder.py
+++ b/src/qiskit_qec/decoders/circuit_matching_decoder.py
@@ -346,7 +346,9 @@ class CircuitModelMatchingDecoder(ABC):
                     )
                     restriction = {x: assignment[x] for x in edge_data["weight_poly"].gens}
                     p = edge_data["weight_poly"].eval(restriction).evalf()
-                    assert p < 0.5, "edge flip probability too large"
+                    # if approximate edge flip probability is large, saturate at 1/2
+                    if p > 0.5:
+                        p = 0.5
                     edge_data["weight"] = log((1 - p) / p)
         self.matcher.preprocess(self.graph)
 


### PR DESCRIPTION
Rather than raise an exception when the approximations appear to break down, instead choose the maximum edge flip probability to be 1/2.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Remove an assertion in circuit_matching_decoder.update_edge_weights and instead threshold the edge probabilities at 1/2.

### Details and comments

This is a three line change. It allows the circuit_matching_decoder to run (and sometimes succeed) in cases where it would otherwise raise an exception.