### PR TITLE
Small fixes to make UnionFind run with real data

### DIFF
--- a/src/qiskit_qec/decoders/hdrg_decoders.py
+++ b/src/qiskit_qec/decoders/hdrg_decoders.py
@@ -319,7 +319,7 @@ class UnionFindDecoder(ClusteringDecoder):
         self.z_logicals.
         """
         self.graph = deepcopy(self.decoding_graph.graph)
-        string = "".join([str(c) for c in string[::-1]])
+        # string = "".join([str(c) for c in string[::-1]]) # we dont need to reverse it. Real data comes in the correct order.
         output = [int(bit) for bit in list(string.split(" ", maxsplit=self.code.d)[0])][::-1]
         highlighted_nodes = self.code.string2nodes(string, all_logicals=True)
         if not highlighted_nodes:
@@ -334,7 +334,8 @@ class UnionFindDecoder(ClusteringDecoder):
                     if node.is_boundary:
                         # FIXME: Find a general way to go from physical qubit
                         # index to code qubit index
-                        qubit_to_be_corrected = int(node.qubits[0] / 2)
+                        # qubit_to_be_corrected = int(node.qubits[0] / 2)
+                        qubit_to_be_corrected = self.code.code_index[node.qubits[0]]
                         output[qubit_to_be_corrected] = (output[qubit_to_be_corrected] + 1) % 2
                 continue
 

--- a/test/union_find/test_union_find.py
+++ b/test/union_find/test_union_find.py
@@ -61,7 +61,7 @@ class UnionFindDecoderTest(TestCase):
             )
             for fault in fault_enumerator.generate():
                 outcome = "".join([str(x) for x in fault[3]])
-                corrected_outcome = decoder.process(outcome)
+                corrected_outcome = decoder.process(outcome[::-1])
                 stabilizers = temp_syndrome(corrected_outcome, code.css_z_stabilizer_ops)
                 for syndrome in stabilizers:
                     self.assertEqual(syndrome, 0)
@@ -83,7 +83,7 @@ class UnionFindDecoderTest(TestCase):
             )
             for fault in fault_enumerator.generate():
                 outcome = "".join([str(x) for x in fault[3]])
-                corrected_outcome = decoder.process(outcome)
+                corrected_outcome = decoder.process(outcome[::-1])
                 stabilizers = temp_syndrome(corrected_outcome, code.css_z_stabilizer_ops)
                 for syndrome in stabilizers:
                     self.assertEqual(syndrome, 0)
@@ -106,7 +106,7 @@ class UnionFindDecoderTest(TestCase):
         )
         for fault in fault_enumerator.generate():
             outcome = "".join([str(x) for x in fault[3]])
-            corrected_outcome = decoder.process(outcome)
+            corrected_outcome = decoder.process(outcome[::-1])
             logical_measurement = temp_syndrome(
                 corrected_outcome, [[int(q / 2) for q in code.z_logicals]]
             )[0]
@@ -143,7 +143,7 @@ class UnionFindDecoderTest(TestCase):
                     string += "0" * (d - 1) + " "
                 string += testcases[sample]
                 # get and check corrected_z_logicals
-                outcome = decoder.process(string)
+                outcome = decoder.process(string[::-1])
                 logical_outcome = sum([outcome[int(z_logical / 2)] for z_logical in z_logicals]) % 2
                 if not logical_outcome == 0:
                     logical_errors += 1


### PR DESCRIPTION
### Summary
Add some quick hacks to try to make the UnionFind Decoder run with real data. Reversal of string order in process() is not needed, and qubit-index fix for the correction is used.


### Details and comments
- This code is necessary to be able to reproduce the code snippet of bug https://github.com/qiskit-community/qiskit-qec/issues/352. 
- Fixed tests of UnionFind by reversing the order of the output from the FaultEnumerator

