### PR TITLE
Test (for CSS codes), black, lint, py39 tests

### DIFF
--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -12,21 +12,27 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name, disable=no-name-in-module
 
 """Generates circuits for CSS codes."""
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit_aer.noise import depolarizing_error, pauli_error
 
+from stim import Circuit as StimCircuit
+from stim import target_rec as StimTarget_rec
+
 from qiskit_qec.utils import DecodingGraphNode
 from qiskit_qec.circuits.code_circuit import CodeCircuit
-from qiskit_qec.utils.stim_tools import noisify_circuit, get_stim_circuits, detector_error_model_to_rx_graph
+from qiskit_qec.utils.stim_tools import (
+    noisify_circuit,
+    get_stim_circuits,
+    detector_error_model_to_rx_graph,
+)
 from qiskit_qec.codes import StabSubSystemCode
 from qiskit_qec.operators.pauli_list import PauliList
 from qiskit_qec.linear.symplectic import normalizer
 from qiskit_qec.exceptions import QiskitQECError
 
-import stim
 
 class CssCodeCircuit(CodeCircuit):
     """
@@ -130,9 +136,7 @@ class CssCodeCircuit(CodeCircuit):
                 self._gauges4stabilizers[j].append(gauges)
 
     def _get_code_properties(self):
-
         if isinstance(self.code, StabSubSystemCode):
-
             is_css = True
 
             raw_gauges = self.code.gauge_group.generators
@@ -148,7 +152,6 @@ class CssCodeCircuit(CodeCircuit):
                 raw_ops,
                 ops,
             ) in zip([raw_gauges, raw_stabilizers, raw_logicals], [gauges, stabilizers, logicals]):
-
                 for op in raw_ops:
                     op = str(op)
                     for j, pauli in enumerate(["X", "Z"]):
@@ -317,84 +320,146 @@ class CssCodeCircuit(CodeCircuit):
 
     def is_cluster_neutral(self, atypical_nodes):
         pass
-    
+
     def stim_circuit_with_detectors(self):
+        """Converts the qiskit circuits into stim ciruits and add detectors.
+        This is required for the stim-based construction of the DecodingGraph.
+        """
         stim_circuits, _ = get_stim_circuits(self.noisy_circuit)
-        measurements_per_cycle = len(self.x_gauges)+len(self.z_gauges)
-        
-        if self.round_schedule[0] == 'x':
-            measurement_round_offset = [0,len(self.x_gauges)]
+        measurements_per_cycle = len(self.x_gauges) + len(self.z_gauges)
+
+        if self.round_schedule[0] == "x":
+            measurement_round_offset = [0, len(self.x_gauges)]
         else:
-            measurement_round_offset = [len(self.z_gauges),0]
+            measurement_round_offset = [len(self.z_gauges), 0]
 
         ## 0th round of measurements
-        if self.basis == 'x':
-            for stabind,stabilizer in enumerate(self.x_stabilizers):
+        if self.basis == "x":
+            for stabind, stabilizer in enumerate(self.x_stabilizers):
                 record_targets = []
                 for gauge_ind in self._gauges4stabilizers[0][stabind]:
-                    record_targets.append(stim.target_rec(measurement_round_offset[0]+gauge_ind-(self.T*measurements_per_cycle + self.code.n)))
+                    record_targets.append(
+                        StimTarget_rec(
+                            measurement_round_offset[0]
+                            + gauge_ind
+                            - (self.T * measurements_per_cycle + self.code.n)
+                        )
+                    )
                 qubits_and_time = stabilizer.copy()
                 qubits_and_time.extend([0])
-                stim_circuits['0'].append("DETECTOR", record_targets, qubits_and_time)
-                stim_circuits['1'].append("DETECTOR", record_targets, qubits_and_time)
+                stim_circuits["0"].append("DETECTOR", record_targets, qubits_and_time)
+                stim_circuits["1"].append("DETECTOR", record_targets, qubits_and_time)
         else:
-            for stabind,stabilizer in enumerate(self.z_stabilizers):
+            for stabind, stabilizer in enumerate(self.z_stabilizers):
                 record_targets = []
                 for gauge_ind in self._gauges4stabilizers[1][stabind]:
-                    record_targets.append(stim.target_rec(measurement_round_offset[1]+gauge_ind-(self.T*measurements_per_cycle + self.code.n)))
+                    record_targets.append(
+                        StimTarget_rec(
+                            measurement_round_offset[1]
+                            + gauge_ind
+                            - (self.T * measurements_per_cycle + self.code.n)
+                        )
+                    )
                 qubits_and_time = stabilizer.copy()
                 qubits_and_time.extend([0])
-                stim_circuits['0'].append("DETECTOR", record_targets, qubits_and_time)
-                stim_circuits['1'].append("DETECTOR", record_targets, qubits_and_time)
+                stim_circuits["0"].append("DETECTOR", record_targets, qubits_and_time)
+                stim_circuits["1"].append("DETECTOR", record_targets, qubits_and_time)
 
-        #adding first x and then z stabilizer comparisons
+        # adding first x and then z stabilizer comparisons
         for j in range(2):
-            circuit = stim.Circuit()
-            for t in range(1,self.T): #compare stabilizer measurements with previous in each round
-                for gind,gs in enumerate(self._gauges4stabilizers[j]):
+            circuit = StimCircuit()
+            for t in range(
+                1, self.T
+            ):  # compare stabilizer measurements with previous in each round
+                for gind, gs in enumerate(self._gauges4stabilizers[j]):
                     record_targets = []
                     for gauge_ind in gs:
-                        record_targets.append(stim.target_rec(t*measurements_per_cycle+measurement_round_offset[j]+gauge_ind-(self.T*measurements_per_cycle + self.code.n)))
-                        record_targets.append(stim.target_rec((t-1)*measurements_per_cycle+measurement_round_offset[j]+gauge_ind-(self.T*measurements_per_cycle + self.code.n)))
+                        record_targets.append(
+                            StimTarget_rec(
+                                t * measurements_per_cycle
+                                + measurement_round_offset[j]
+                                + gauge_ind
+                                - (self.T * measurements_per_cycle + self.code.n)
+                            )
+                        )
+                        record_targets.append(
+                            StimTarget_rec(
+                                (t - 1) * measurements_per_cycle
+                                + measurement_round_offset[j]
+                                + gauge_ind
+                                - (self.T * measurements_per_cycle + self.code.n)
+                            )
+                        )
                     qubits_and_time = self._stabilizers[j][gind].copy()
                     qubits_and_time.extend([t])
                     circuit.append("DETECTOR", record_targets, qubits_and_time)
-            stim_circuits['0'] += circuit
-            stim_circuits['1'] += circuit
-        
-        ## final measurements        
-        if self.basis == 'x':
-            for stabind,stabilizer in enumerate(self.x_stabilizers):
+            stim_circuits["0"] += circuit
+            stim_circuits["1"] += circuit
+
+        ## final measurements
+        if self.basis == "x":
+            for stabind, stabilizer in enumerate(self.x_stabilizers):
                 record_targets = []
                 for q in stabilizer:
-                    record_targets.append(stim.target_rec(q - self.code.n))
+                    record_targets.append(StimTarget_rec(q - self.code.n))
                 for gauge_ind in self._gauges4stabilizers[0][stabind]:
-                    record_targets.append(stim.target_rec(measurement_round_offset[0]+gauge_ind-self.code.n-measurements_per_cycle))
+                    record_targets.append(
+                        StimTarget_rec(
+                            measurement_round_offset[0]
+                            + gauge_ind
+                            - self.code.n
+                            - measurements_per_cycle
+                        )
+                    )
                 qubits_and_time = stabilizer.copy()
                 qubits_and_time.extend([self.T])
-                stim_circuits['0'].append("DETECTOR", record_targets, qubits_and_time)
-                stim_circuits['1'].append("DETECTOR", record_targets, qubits_and_time)
-            stim_circuits['0'].append("OBSERVABLE_INCLUDE",[stim.target_rec(q - self.code.n) for q in sorted(self.logical_x[0])],0)
-            stim_circuits['1'].append("OBSERVABLE_INCLUDE",[stim.target_rec(q - self.code.n) for q in sorted(self.logical_x[0])],0) 
+                stim_circuits["0"].append("DETECTOR", record_targets, qubits_and_time)
+                stim_circuits["1"].append("DETECTOR", record_targets, qubits_and_time)
+            stim_circuits["0"].append(
+                "OBSERVABLE_INCLUDE",
+                [StimTarget_rec(q - self.code.n) for q in sorted(self.logical_x[0])],
+                0,
+            )
+            stim_circuits["1"].append(
+                "OBSERVABLE_INCLUDE",
+                [StimTarget_rec(q - self.code.n) for q in sorted(self.logical_x[0])],
+                0,
+            )
         else:
-            for stabind,stabilizer in enumerate(self.z_stabilizers):
+            for stabind, stabilizer in enumerate(self.z_stabilizers):
                 record_targets = []
                 for q in stabilizer:
-                    record_targets.append(stim.target_rec(q - self.code.n))
+                    record_targets.append(StimTarget_rec(q - self.code.n))
                 for gauge_ind in self._gauges4stabilizers[1][stabind]:
-                    record_targets.append(stim.target_rec(measurement_round_offset[1]+gauge_ind-self.code.n-measurements_per_cycle))
+                    record_targets.append(
+                        StimTarget_rec(
+                            measurement_round_offset[1]
+                            + gauge_ind
+                            - self.code.n
+                            - measurements_per_cycle
+                        )
+                    )
                 qubits_and_time = stabilizer.copy()
                 qubits_and_time.extend([self.T])
-                stim_circuits['0'].append("DETECTOR", record_targets, qubits_and_time)
-                stim_circuits['1'].append("DETECTOR", record_targets, qubits_and_time)
-            stim_circuits['0'].append("OBSERVABLE_INCLUDE",[stim.target_rec(q - self.code.n) for q in sorted(self.logical_z[0])],0)
-            stim_circuits['1'].append("OBSERVABLE_INCLUDE",[stim.target_rec(q - self.code.n) for q in sorted(self.logical_z[0])],0)
+                stim_circuits["0"].append("DETECTOR", record_targets, qubits_and_time)
+                stim_circuits["1"].append("DETECTOR", record_targets, qubits_and_time)
+            stim_circuits["0"].append(
+                "OBSERVABLE_INCLUDE",
+                [StimTarget_rec(q - self.code.n) for q in sorted(self.logical_z[0])],
+                0,
+            )
+            stim_circuits["1"].append(
+                "OBSERVABLE_INCLUDE",
+                [StimTarget_rec(q - self.code.n) for q in sorted(self.logical_z[0])],
+                0,
+            )
 
         return stim_circuits
-    
+
     def _make_syndrome_graph(self):
-        stim_circuit = self.stim_circuit_with_detectors()['0']
-        e = stim_circuit.detector_error_model(decompose_errors=True, approximate_disjoint_errors=True)
+        stim_circuit = self.stim_circuit_with_detectors()["0"]
+        e = stim_circuit.detector_error_model(
+            decompose_errors=True, approximate_disjoint_errors=True
+        )
         graph, hyperedges = detector_error_model_to_rx_graph(e)
         return graph, hyperedges
-    

--- a/src/qiskit_qec/utils/decoding_graph_attributes.py
+++ b/src/qiskit_qec/utils/decoding_graph_attributes.py
@@ -56,9 +56,12 @@ class DecodingGraphNode:
         elif key in self.properties:
             return self.properties[key]
         else:
-            raise QiskitQECError("'" + str(key) + "'" + " is not an an attribute or property of the node.")
+            raise QiskitQECError(
+                "'" + str(key) + "'" + " is not an an attribute or property of the node."
+            )
 
-    def get(self, key, default):
+    def get(self, key, _):
+        """A dummy docstring."""
         return self.__getitem__(key)
 
     def __setitem__(self, key, value):
@@ -66,6 +69,7 @@ class DecodingGraphNode:
             self.__dict__[key] = value
         else:
             self.properties[key] = value
+
     def __eq__(self, rhs):
         if not isinstance(rhs, DecodingGraphNode):
             return NotImplemented
@@ -86,8 +90,9 @@ class DecodingGraphNode:
         for attr, value in self.__dict__.items():
             yield attr, value
 
-    def __str__ (self):
+    def __str__(self):
         return str(dict(self))
+
 
 @dataclass
 class DecodingGraphEdge:
@@ -112,9 +117,12 @@ class DecodingGraphEdge:
         elif key in self.properties:
             return self.properties[key]
         else:
-            raise QiskitQECError("'" + str(key) + "'" + " is not an an attribute or property of the edge.")
+            raise QiskitQECError(
+                "'" + str(key) + "'" + " is not an an attribute or property of the edge."
+            )
 
-    def get(self, key, default):
+    def get(self, key, _):
+        """A dummy docstring."""
         return self.__getitem__(key)
 
     def __setitem__(self, key, value):
@@ -122,7 +130,7 @@ class DecodingGraphEdge:
             self.__dict__[key] = value
         else:
             self.properties[key] = value
-            
+
     def __eq__(self, rhs) -> bool:
         if not isinstance(rhs, DecodingGraphNode):
             return NotImplemented
@@ -136,5 +144,5 @@ class DecodingGraphEdge:
         for attr, value in self.__dict__.items():
             yield attr, value
 
-    def __str__ (self):
+    def __str__(self):
         return str(dict(self))

--- a/src/qiskit_qec/utils/stim_tools.py
+++ b/src/qiskit_qec/utils/stim_tools.py
@@ -15,21 +15,22 @@
 # pylint: disable=invalid-name, disable=no-name-in-module
 
 """Tools to use functionality from Stim."""
-
+from typing import List, Dict
+from math import log
 from stim import Circuit as StimCircuit
 from stim import DetectorErrorModel as StimDetectorErrorModel
 from stim import DemInstruction as StimDemInstruction
 from stim import DemTarget as StimDemTarget
+
+import numpy as np
+import rustworkx as rx
+
 
 from qiskit import QuantumCircuit
 from qiskit_aer.noise.errors.quantum_error import QuantumChannelInstruction
 from qiskit_aer.noise import pauli_error
 from qiskit_qec.utils.decoding_graph_attributes import DecodingGraphNode, DecodingGraphEdge
 
-import rustworkx as rx
-from typing import List, Dict
-import numpy as np
-from math import log
 
 def get_stim_circuits(circuit_dict):
     """Converts compatible qiskit circuits to stim circuits.
@@ -163,7 +164,6 @@ def get_counts_via_stim(circuits, shots: int = 4000, noise_model=None):
 
     counts = []
     for circuit in circuits:
-
         stim_circuits, stim_measurement_data = get_stim_circuits({"": circuit})
         stim_circuit = stim_circuits[""]
         measurement_data = stim_measurement_data[""]
@@ -190,11 +190,12 @@ def get_counts_via_stim(circuits, shots: int = 4000, noise_model=None):
 
     return counts
 
+
 def detector_error_model_to_rx_graph(model: StimDetectorErrorModel) -> rx.PyGraph:
     """Convert a stim error model into a RustworkX graph.
-       It assumes that the stim circuit does not contain repeat blocks.
-       Later on repeat blocks should be handled to make this function compatible with
-       user-defined stim circuits.
+    It assumes that the stim circuit does not contain repeat blocks.
+    Later on repeat blocks should be handled to make this function compatible with
+    user-defined stim circuits.
     """
 
     g = rx.PyGraph(multigraph=False)
@@ -208,12 +209,12 @@ def detector_error_model_to_rx_graph(model: StimDetectorErrorModel) -> rx.PyGrap
             qubits = [int(qubit_ind) for qubit_ind in a[:-1]]
             for t in instruction.targets_copy():
                 node = DecodingGraphNode(index=t.val, time=time, qubits=qubits)
-                index_to_DecodingGraphNode[t.val]=node
+                index_to_DecodingGraphNode[t.val] = node
                 g.add_node(node)
-    
+
     trivial_boundary_node = DecodingGraphNode(index=model.num_detectors, time=0, is_boundary=True)
     g.add_node(trivial_boundary_node)
-    index_to_DecodingGraphNode[model.num_detectors]=trivial_boundary_node
+    index_to_DecodingGraphNode[model.num_detectors] = trivial_boundary_node
 
     def handle_error(p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict):
         if p == 0:
@@ -228,23 +229,32 @@ def detector_error_model_to_rx_graph(model: StimDetectorErrorModel) -> rx.PyGrap
             #     dets = [dets[0], model.num_detectors+1]
         if len(dets) > 2:
             raise NotImplementedError(
-                f"Error with more than 2 symptoms can't become an edge or boundary edge: {dets!r}.")
-        if g.has_edge(dets[0],dets[1]):
-            edge_ind = [dets for dets in g.edge_list()].index((dets[0],dets[1]))
+                f"Error with more than 2 symptoms can't become an edge or boundary edge: {dets!r}."
+            )
+        if g.has_edge(dets[0], dets[1]):
+            edge_ind = list(g.edge_list()).index((dets[0], dets[1]))
             edge_data = g.edges()[edge_ind].properties
             old_p = edge_data["error_probability"]
             old_frame_changes = edge_data["fault_ids"]
             # If frame changes differ, the code has distance 2; just keep whichever was first.
             if set(old_frame_changes) == set(frame_changes):
                 p = p * (1 - old_p) + old_p * (1 - p)
-                g.remove_edge(dets[0],dets[1])
+                g.remove_edge(dets[0], dets[1])
         if p > 0.5:
             p = 1 - p
         if p > 0:
-            qubits = list(set(index_to_DecodingGraphNode[dets[0]].qubits).intersection(index_to_DecodingGraphNode[dets[1]].qubits))
-            edge = DecodingGraphEdge(qubits=qubits,weight=log((1 - p) / p), properties={'fault_ids': set(frame_changes), 'error_probability': p})
-            g.add_edge(dets[0],dets[1], edge)
-            hyperedge[dets[0],dets[1]] = edge
+            qubits = list(
+                set(index_to_DecodingGraphNode[dets[0]].qubits).intersection(
+                    index_to_DecodingGraphNode[dets[1]].qubits
+                )
+            )
+            edge = DecodingGraphEdge(
+                qubits=qubits,
+                weight=log((1 - p) / p),
+                properties={"fault_ids": set(frame_changes), "error_probability": p},
+            )
+            g.add_edge(dets[0], dets[1], edge)
+            hyperedge[dets[0], dets[1]] = edge
 
     hyperedges = []
 
@@ -268,7 +278,7 @@ def detector_error_model_to_rx_graph(model: StimDetectorErrorModel) -> rx.PyGrap
                         dets = []
                 # Handle last component.
                 handle_error(p, dets, frames, hyperedge)
-                if len(hyperedge)>1:
+                if len(hyperedge) > 1:
                     hyperedges.append(hyperedge)
             elif instruction.type == "detector":
                 pass
@@ -280,6 +290,7 @@ def detector_error_model_to_rx_graph(model: StimDetectorErrorModel) -> rx.PyGrap
             raise NotImplementedError()
 
     return g, hyperedges
+
 
 def noisify_circuit(circuits, noise_model):
     """
@@ -307,7 +318,6 @@ def noisify_circuit(circuits, noise_model):
 
     noisy_circuits = []
     for qc in circuits:
-
         noisy_qc = QuantumCircuit()
         for qreg in qc.qregs:
             noisy_qc.add_register(qreg)

--- a/test/code_circuits/test_css_codes_with_stim.py
+++ b/test/code_circuits/test_css_codes_with_stim.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=invalid-name
+
+"""Test for the CSSCodeCircuit class for Heavy-HEX code with pymatching"""
+import unittest
+import pymatching
+
+from qiskit_qec.codes.hhc import HHC
+from qiskit_qec.circuits.css_code import CssCodeCircuit
+from qiskit_qec.decoders.decoding_graph import DecodingGraph
+
+
+class TestCircuitMatcher(unittest.TestCase):
+    """Test for the CSSCodeCircuit class for Heavy-HEX code with pymatching"""
+
+    def LogFailureDists(self, error_rate: float):
+        """Constructs the stim circuit and the decoding graph (via a stim DetectorErrorModel)
+        for the heavy-hex code and tests it on 10_000 samples for distance 3 and 5.
+        Returns the logical failure for distance 3 and 5 at the specified error rate.
+        Below ~100_000 shotss, the runtime is limited by the decoding graph construction,
+        not the sampling."""
+        dist_list = [3, 5]
+        num_shots = 10_000
+        Log_fail_d = []
+        for d in dist_list:
+            code = HHC(d)
+            css_code = CssCodeCircuit(code, T=d, basis="x", noise_model=(error_rate, error_rate))
+            graph = DecodingGraph(css_code).graph
+            m = pymatching.Matching(graph)
+            stim_circuit = css_code.stim_circuit_with_detectors()["0"]
+            stim_sampler = stim_circuit.compile_detector_sampler()
+            num_correct = 0
+            stim_samples = stim_sampler.sample(num_shots, append_observables=True)
+            for sample in stim_samples:
+                actual_observable = sample[-1]
+                detectors_only = sample.copy()
+                detectors_only[-1] = 0
+                predicted_observable = m.decode(detectors_only)[0]
+                num_correct += actual_observable == predicted_observable
+            Log_fail_d.append((num_shots - num_correct) / num_shots)
+        return Log_fail_d
+
+    def test_HHC(self):
+        """Tests the order of logical failure rates for two distances.
+        One test is below threshold, one is above. (Threshold ~3.5% for the test code)
+        Runtime is approx 5 seconds."""
+        error_rate = 0.01  # this should be below threshold
+        LogFailDist = self.LogFailureDists(error_rate)
+        self.assertTrue(LogFailDist[0] > 2 * LogFailDist[1])
+
+        error_rate = 0.1  # this should be above threshold
+        LogFailDist = self.LogFailureDists(error_rate)
+        self.assertTrue(LogFailDist[0] < LogFailDist[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I added the test for Stim-based decoding graph generation and using it to calculate the logical failure above and below the error threshold for different distances.

This branch passed: black, lint, and py39 tests.

Remark: The union find decoder test failed once when I ran 'tox -epy39', but for other times it always passed. Maybe more shots would be needed there?!