### PR TITLE
capping qiskit-terra version due to deprecation warning for qiskit.qu…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.21.2
+qiskit-terra>=0.21.2, <0.24.0
 qiskit-aer>=0.11.0
 pybind11<=2.9.1
 PyMatching>=0.6.0,!=2.0.0


### PR DESCRIPTION
…antum_info.operators.symplectic.clifford.Clifford.stabilizer

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixing #365 
Capping terra at <0.24.0 for since due to the deprecation of `qiskit.quantum_info.operators.symplectic.clifford.Clifford.stabilizer`

### Details and comments

