### PR TITLE
Default Jupyter notebooks thumbnails

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,5 +65,9 @@ nbsphinx_timeout = 180
 # a separate job
 # nbsphinx_execute = os.getenv('QISKIT_DOCS_BUILD_TUTORIALS', 'never')
 nbsphinx_execute = "never"
+nbsphinx_thumbnails = {
+    # Default image for thumbnails.
+    "**": "_static/images/logo.png",
+}
 nbsphinx_widgets_path = ""
 exclude_patterns = ["_build", "**.ipynb_checkpoints"]

--- a/docs/how_tos/1-how-to-create-codes.ipynb
+++ b/docs/how_tos/1-how-to-create-codes.ipynb
@@ -449,7 +449,11 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/how_tos/2-how-to-work-with-shape-objects.ipynb
+++ b/docs/how_tos/2-how-to-work-with-shape-objects.ipynb
@@ -115,7 +115,11 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "4cc2c85f",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "data": {

--- a/docs/tutorials/QEC_Framework_IEEE_2022.ipynb
+++ b/docs/tutorials/QEC_Framework_IEEE_2022.ipynb
@@ -3422,7 +3422,11 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "f0a623d3-21ef-4abe-a39b-210c00b509e4",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbsphinx-thumbnail"
+    ]
+   },
    "outputs": [
     {
      "data": {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->
### Summary
This PR adds a default thumbnail for the Jupyter notebooks. In the following screenshots we can see the change:

**Without a default thumbnail:**
<img width="658" alt="Screenshot 2023-10-18 at 18 25 23" src="https://github.com/qiskit-community/qiskit-qec/assets/47946624/b411d072-bfb4-4c57-ac2c-18fe6b3bb8fd">

**With a default thumbnail:**
<img width="621" alt="Screenshot 2023-10-18 at 18 26 19" src="https://github.com/qiskit-community/qiskit-qec/assets/47946624/e312af37-a2bc-4a79-8abf-2e939453e227">