### PR TITLE
404 stim compatibility

### DIFF
--- a/src/qiskit_qec/circuits/__init__.py
+++ b/src/qiskit_qec/circuits/__init__.py
@@ -34,3 +34,4 @@ from .code_circuit import CodeCircuit
 from .repetition_code import RepetitionCodeCircuit, ArcCircuit
 from .surface_code import SurfaceCodeCircuit
 from .css_code import CSSCodeCircuit
+from .stim_code_circuit import StimCodeCircuit

--- a/src/qiskit_qec/circuits/code_circuit.py
+++ b/src/qiskit_qec/circuits/code_circuit.py
@@ -53,6 +53,14 @@ class CodeCircuit(ABC):
         pass
 
     @abstractmethod
+    def measured_logicals(self):
+        """
+        Returns a list of logical operators, each expressed as a list of qubits for which
+        the parity of the final readouts corresponds to the raw logical readout.
+        """
+        pass
+
+    @abstractmethod
     def check_nodes(self, nodes, ignore_extra_boundary=False, minimal=False):
         """
         Determines whether a given set of nodes are neutral. If so, also

--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -141,10 +141,7 @@ class CSSCodeCircuit(CodeCircuit):
             stabilizers = [[], []]
             logicals = [[], []]
 
-            for (
-                raw_ops,
-                ops,
-            ) in zip(
+            for (raw_ops, ops,) in zip(
                 [raw_gauges, raw_stabilizers, raw_logicals],
                 [gauges, stabilizers, logicals],
             ):
@@ -152,9 +149,7 @@ class CSSCodeCircuit(CodeCircuit):
                     op = str(op)
                     for j, pauli in enumerate(["X", "Z"]):
                         if (op.count(pauli) + op.count("I")) == self.code.n:
-                            ops[j].append(
-                                [k for k, p in enumerate(op[::-1]) if p == pauli]
-                            )
+                            ops[j].append([k for k, p in enumerate(op[::-1]) if p == pauli])
                 is_css = is_css and (len(ops[0]) + len(ops[1])) == len(raw_ops)
 
             # extra stabilizers: the product of all others
@@ -268,7 +263,7 @@ class CSSCodeCircuit(CodeCircuit):
             logicals=self.logicals,
             clbits=self.circuit["0"].clbits,
             det_ref_values=0,
-            **kwargs
+            **kwargs,
         )
         return nodes
 

--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -186,6 +186,13 @@ class CSSCodeCircuit(CodeCircuit):
         self.css_x_logical = self.logical_x
         self.css_z_logical = self.logical_z
 
+    def measured_logicals(self):
+        if self.basis == "x":
+            measured_logicals = self.logical_x
+        else:
+            measured_logicals = self.logical_z
+        return measured_logicals
+
     def _prepare_initial_state(self, qc, qregs, state):
         if state[0] == "1":
             if self.basis == "z":

--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -48,15 +48,15 @@ class CSSCodeCircuit(CodeCircuit):
         """
         Args:
             code: A CSS code class which is either
-                a) StabSubSystemCode
-                b) a class with the following methods:
-                    'x_gauges' (as a list of list of qubit indices),
-                    'z_gauges',
-                    'x_stabilizers',
-                    'z_stabilizers',
-                    'logical_x',
-                    'logical_z',
-                    'n' (number of qubits),
+            a) StabSubSystemCode
+            b) a class with the following methods:
+                'x_gauges' (as a list of list of qubit indices),
+                'z_gauges',
+                'x_stabilizers',
+                'z_stabilizers',
+                'logical_x',
+                'logical_z',
+                'n' (number of qubits),
             T: Number of syndrome measurement rounds
             basis: basis for encoding ('x' or 'z')
             round_schedule: Order in which to measureme gauge operators ('zx' or 'xz')
@@ -64,6 +64,7 @@ class CSSCodeCircuit(CodeCircuit):
             If a tuple, a pnenomological noise model is used with the entries being
             probabity of depolarizing noise on code qubits between rounds and
             probability of measurement errors, respectively.
+
         Examples:
             The QuantumCircuit of a memory experiment for the distance-3 HeavyHEX code
             >>> from qiskit_qec.codes.hhc import HHC
@@ -255,14 +256,16 @@ class CSSCodeCircuit(CodeCircuit):
         """
         Convert output string from circuits into a set of nodes for
         `DecodingGraph`.
+
         Args:
             string (string): Results string to convert.
             kwargs (dict): Any additional keyword arguments.
                 logical (str): Logical value whose results are used ('0' as default).
                 all_logicals (bool): Whether to include logical nodes
                 irrespective of value. (False as default).
+
         Returns:
-            a list of 'DecodingGraphNode()'-s corresponding to the triggered detectors
+            nodes: a list of 'DecodingGraphNode()'s corresponding to the triggered detectors
         """
 
         nodes = string2nodes_with_detectors(
@@ -280,6 +283,7 @@ class CSSCodeCircuit(CodeCircuit):
         Converts output string into a list of logical measurement outcomes
         Logicals are the logical measurements produced by self.stim_detectors()
         """
+
         _, self.logicals = self.stim_detectors()
 
         log_outs = string2logical_meas(string, self.logicals, self.circuit["0"].clbits)
@@ -293,15 +297,17 @@ class CSSCodeCircuit(CodeCircuit):
 
     def stim_detectors(self):
         """
+        Constructs detectors and logicals required for stim.
+
         Returns:
-            detectors (list[dict]) are dictionaries containing
-                a) 'clbits', the classical bits (register, index) included in the measurement comparisons
-                b) 'qubits', the qubits (list of indices) participating in the stabilizer measurements
-                c) 'time', measurement round (int) of the earlier measurements in the detector
-                d) 'basis', the pauli basis ('x' or 'z') of the stabilizers
-            logicals (list[dict]) are dictionaries containing
-                a) 'clbits', the classical bits (register, index) included in the logical measurement
-                b) 'basis', the pauli basis ('x' or 'z') of the logical
+            detectors (list[dict]): dictionaries containing
+            a) 'clbits', the classical bits (register, index) included in the measurement comparisons
+            b) 'qubits', the qubits (list of indices) participating in the stabilizer measurements
+            c) 'time', measurement round (int) of the earlier measurements in the detector
+            d) 'basis', the pauli basis ('x' or 'z') of the stabilizers
+            logicals (list[dict]): dictionaries containing
+            a) 'clbits', the classical bits (register, index) included in the logical measurement
+            b) 'basis', the pauli basis ('x' or 'z') of the logical
         """
 
         detectors = []

--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -128,7 +128,7 @@ class CSSCodeCircuit(CodeCircuit):
                     if set(stabilizer).intersection(set(gauge)) == set(gauge):
                         gauges.append(g)
                 self._gauges4stabilizers[j].append(gauges)
-    self.detectors, self.logicals = self.stim_detectors()
+        self.detectors, self.logicals = self.stim_detectors()
 
     def _get_code_properties(self):
         if isinstance(self.code, StabSubSystemCode):

--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -268,17 +268,16 @@ class CSSCodeCircuit(CodeCircuit):
         )
         return nodes
 
-    def string2raw_logicals(self,string):
+    def string2raw_logicals(self, string):
         """
         Converts output string into a list of logical measurement outcomes
         Logicals are the logical measurements produced by self.stim_detectors()
         """
-        _,self.logicals = self.stim_detectors()
-        
-        log_outs = string2logical_meas(string, self.logicals,self.circuit["0"].clbits)
+        _, self.logicals = self.stim_detectors()
 
+        log_outs = string2logical_meas(string, self.logicals, self.circuit["0"].clbits)
         return log_outs
-    
+
     def check_nodes(self, nodes, ignore_extra_boundary=False, minimal=False):
         raise NotImplementedError
 

--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -128,6 +128,7 @@ class CSSCodeCircuit(CodeCircuit):
                     if set(stabilizer).intersection(set(gauge)) == set(gauge):
                         gauges.append(g)
                 self._gauges4stabilizers[j].append(gauges)
+    self.detectors, self.logicals = self.stim_detectors()
 
     def _get_code_properties(self):
         if isinstance(self.code, StabSubSystemCode):
@@ -256,7 +257,6 @@ class CSSCodeCircuit(CodeCircuit):
         Returns:
             a list of 'DecodingGraphNode()'-s corresponding to the triggered detectors
         """
-        self.detectors, self.logicals = self.stim_detectors()
 
         nodes = string2nodes_with_detectors(
             string=string,

--- a/src/qiskit_qec/circuits/css_code.py
+++ b/src/qiskit_qec/circuits/css_code.py
@@ -24,6 +24,7 @@ from qiskit_qec.utils.stim_tools import (
     get_stim_circuits,
     detector_error_model_to_rx_graph,
     string2nodes_with_detectors,
+    string2logical_meas,
 )
 from qiskit_qec.codes import StabSubSystemCode
 from qiskit_qec.operators.pauli_list import PauliList
@@ -267,6 +268,17 @@ class CSSCodeCircuit(CodeCircuit):
         )
         return nodes
 
+    def string2raw_logicals(self,string):
+        """
+        Converts output string into a list of logical measurement outcomes
+        Logicals are the logical measurements produced by self.stim_detectors()
+        """
+        _,self.logicals = self.stim_detectors()
+        
+        log_outs = string2logical_meas(string, self.logicals,self.circuit["0"].clbits)
+
+        return log_outs
+    
     def check_nodes(self, nodes, ignore_extra_boundary=False, minimal=False):
         raise NotImplementedError
 

--- a/src/qiskit_qec/circuits/repetition_code.py
+++ b/src/qiskit_qec/circuits/repetition_code.py
@@ -241,6 +241,9 @@ class RepetitionCodeCircuit(CodeCircuit):
             self.circuit[log].add_register(self.code_bit)
             self.circuit[log].measure(self.code_qubit, self.code_bit)
 
+    def measured_logicals(self):
+        return [[0]]
+
     def _process_string(self, string):
         # logical readout taken from
         measured_log = string[0] + " " + string[self.d - 1]
@@ -349,7 +352,7 @@ class RepetitionCodeCircuit(CodeCircuit):
         Returns:
             list: Raw values for logical operators that correspond to nodes.
         """
-        return _separate_string(self._process_string(string))[0]
+        return string.split(" ", maxsplit=1)[0][-1]
 
     def check_nodes(self, nodes, ignore_extra_boundary=False, minimal=False):
         """
@@ -963,6 +966,9 @@ class ArcCircuit(CodeCircuit):
                 # otherwise, code qubits are already prepped
             qc.add_register(self.code_bit)
             qc.measure(self.code_qubit, self.code_bit)
+
+    def measured_logicals(self):
+        return [[self.z_logicals[0]]]
 
     def _process_string(self, string):
         # logical readout taken from assigned qubits

--- a/src/qiskit_qec/circuits/stim_code_circuit.py
+++ b/src/qiskit_qec/circuits/stim_code_circuit.py
@@ -27,6 +27,7 @@ from qiskit_qec.utils.stim_tools import (
     string2nodes_with_detectors,
 )
 
+
 class StimCodeCircuit(CodeCircuit):
     """
     Prepares a CodeCircuit class based on the supplied stim circuit.
@@ -98,34 +99,24 @@ class StimCodeCircuit(CodeCircuit):
                         if inst_name == "QUBIT_COORDS":
                             m = 1
                         elif inst_name in single_qubit_gate_dict.keys():
-                            qubits = [
-                                target.value for target in instruction.targets_copy()
-                            ]
+                            qubits = [target.value for target in instruction.targets_copy()]
                             for q in qubits:
-                                self.qc.append(
-                                    single_qubit_gate_dict[inst_name], qargs=[q]
-                                )
+                                self.qc.append(single_qubit_gate_dict[inst_name], qargs=[q])
                         elif inst_name in two_qubit_gate_dict.keys():
                             stim_targets = instruction.targets_copy()
                             for t1, t2 in zip(stim_targets[::2], stim_targets[1::2]):
                                 if t1.is_qubit_target:
                                     q1, q2 = t1.value, t2.value
-                                    self.qc.append(
-                                        two_qubit_gate_dict[inst_name], qargs=[q1, q2]
-                                    )
+                                    self.qc.append(two_qubit_gate_dict[inst_name], qargs=[q1, q2])
                                 elif t1.is_measurement_record_target:
                                     c1, q2 = t1.value, t2.value
-                                    inst_name = inst_name[
-                                        1:
-                                    ]  # remove the C from CX,CY,CZ
+                                    inst_name = inst_name[1:]  # remove the C from CX,CY,CZ
                                     self.qc.append(
                                         single_qubit_gate_dict[inst_name], qargs=[q2]
                                     ).c_if(c1, 1)
 
                         elif inst_name == "M":
-                            qubits = [
-                                target.value for target in instruction.targets_copy()
-                            ]
+                            qubits = [target.value for target in instruction.targets_copy()]
                             invert_result = [
                                 target.is_inverted_result_target
                                 for target in instruction.targets_copy()
@@ -148,9 +139,7 @@ class StimCodeCircuit(CodeCircuit):
                                 )
                             creg = ClassicalRegister(len(qubits), name=cl_reg_name)
                             self.qc.add_register(creg)
-                            flip_qubits = [
-                                q for q, inv in zip(qubits, invert_result) if inv
-                            ]
+                            flip_qubits = [q for q, inv in zip(qubits, invert_result) if inv]
                             if flip_qubits != []:
                                 self.qc.x(flip_qubits)
                             self.qc.measure(qubits, creg)
@@ -160,9 +149,7 @@ class StimCodeCircuit(CodeCircuit):
                                 self.qc.x(flip_qubits)
                             meas_count += 1
                         elif inst_name == "R":
-                            qubits = [
-                                target.value for target in instruction.targets_copy()
-                            ]
+                            qubits = [target.value for target in instruction.targets_copy()]
                             self.qc.reset(qubits)
 
                         elif inst_name == "TICK" and barriers:
@@ -172,10 +159,7 @@ class StimCodeCircuit(CodeCircuit):
                             meas_targets = [t.value for t in instruction.targets_copy()]
                             self.detectors.append(
                                 {
-                                    "clbits": [
-                                        self.measurement_data[ind]
-                                        for ind in meas_targets
-                                    ],
+                                    "clbits": [self.measurement_data[ind] for ind in meas_targets],
                                     "time": [],
                                     "qubits": [],
                                     "stim_coords": instruction.gate_args_copy(),
@@ -184,12 +168,7 @@ class StimCodeCircuit(CodeCircuit):
                         elif inst_name == "OBSERVABLE_INCLUDE":
                             meas_targets = [t.value for t in instruction.targets_copy()]
                             self.logicals.append(
-                                {
-                                    "clbits": [
-                                        self.measurement_data[ind]
-                                        for ind in meas_targets
-                                    ]
-                                }
+                                {"clbits": [self.measurement_data[ind] for ind in meas_targets]}
                             )
 
         rep_block_count = 0
@@ -209,8 +188,7 @@ class StimCodeCircuit(CodeCircuit):
             [clbit_dict[clbit] for clbit in det["clbits"]] for det in self.detectors
         ]
         self.det_ref_values = [
-            sum(noiseless_measurements[meas_list]) % 2
-            for meas_list in detector_meas_indices
+            sum(noiseless_measurements[meas_list]) % 2 for meas_list in detector_meas_indices
         ]
 
         # further code parameters
@@ -419,8 +397,7 @@ class StimCodeCircuit(CodeCircuit):
                             target_list
                         ):  # avoiding overlaps that result from stim broadcating
                             target_list = [
-                                target_list[i : i + 2]
-                                for i in range(0, len(target_list), 2)
+                                target_list[i : i + 2] for i in range(0, len(target_list), 2)
                             ]
                         else:
                             target_list = [target_list]
@@ -429,17 +406,13 @@ class StimCodeCircuit(CodeCircuit):
                                 if len(qubit_ind) == 2:
                                     qubit_list = [
                                         target_pair[q_ind].value
-                                        for target_pair in zip(
-                                            targets[::2], targets[1::2]
-                                        )
+                                        for target_pair in zip(targets[::2], targets[1::2])
                                         for q_ind in qubit_ind
                                     ]
                                 else:
                                     qubit_list = [
                                         target_pair[qubit_ind[0]].value
-                                        for target_pair in zip(
-                                            targets[::2], targets[1::2]
-                                        )
+                                        for target_pair in zip(targets[::2], targets[1::2])
                                     ]
 
                                 if gate == "M":
@@ -449,9 +422,7 @@ class StimCodeCircuit(CodeCircuit):
                                             + target_pair[1].is_inverted_result_target
                                         )
                                         % 2
-                                        for target_pair in zip(
-                                            targets[::2], targets[1::2]
-                                        )
+                                        for target_pair in zip(targets[::2], targets[1::2])
                                     ]
                                     for i, inv in enumerate(inv_list):
                                         if inv:
@@ -465,8 +436,7 @@ class StimCodeCircuit(CodeCircuit):
                             qubit_list = [target.value for target in target_list]
                             if gate == "M":
                                 inv_list = [
-                                    target.is_inverted_result_target
-                                    for target in target_list
+                                    target.is_inverted_result_target for target in target_list
                                 ]
                                 for i, inv in enumerate(inv_list):
                                     if inv:
@@ -579,7 +549,7 @@ class StimCodeCircuit(CodeCircuit):
             logicals=self.logicals,
             clbits=self.qc.clbits,
             det_ref_values=self.det_ref_values,
-            **kwargs
+            **kwargs,
         )
         return nodes
 
@@ -587,9 +557,7 @@ class StimCodeCircuit(CodeCircuit):
         e = self.stim_circuit.detector_error_model(
             decompose_errors=True, approximate_disjoint_errors=True
         )
-        graph, hyperedges = detector_error_model_to_rx_graph(
-            e, detectors=self.detectors
-        )
+        graph, hyperedges = detector_error_model_to_rx_graph(e, detectors=self.detectors)
         return graph, hyperedges
 
     def check_nodes(self, nodes, ignore_extra_boundary=False, minimal=False):

--- a/src/qiskit_qec/circuits/stim_code_circuit.py
+++ b/src/qiskit_qec/circuits/stim_code_circuit.py
@@ -12,8 +12,9 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=invalid-name, disable=no-name-in-module
+# pylint: disable=invalid-name, disable=no-name-in-module, disable=no-member
 
+"""Generates CodeCircuits from stim circuits"""
 import warnings
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
@@ -112,9 +113,7 @@ class StimCodeCircuit(CodeCircuit):
                         rep_block_count += 1
                     elif isinstance(instruction, CircuitInstruction):
                         inst_name = instruction.name
-                        if inst_name == "QUBIT_COORDS":
-                            m = 1
-                        elif inst_name in single_qubit_gate_dict:
+                        if inst_name in single_qubit_gate_dict:
                             qubits = [target.value for target in instruction.targets_copy()]
                             for q in qubits:
                                 self.qc.append(single_qubit_gate_dict[inst_name], qargs=[q])
@@ -211,7 +210,7 @@ class StimCodeCircuit(CodeCircuit):
         # further code parameters
         try:
             self.d = len(self.stim_circuit.shortest_graphlike_error())  # code distance
-        except:
+        except ValueError:
             self.d = 0
         self.n = stim_circuit.num_qubits
         # the number of rounds is not necessarily well-defined (Floquet codes etc.)

--- a/src/qiskit_qec/circuits/stim_code_circuit.py
+++ b/src/qiskit_qec/circuits/stim_code_circuit.py
@@ -1,0 +1,599 @@
+import warnings
+
+from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+from qiskit.circuit.library.standard_gates import (
+    IGate,
+    XGate,
+    YGate,
+    ZGate,
+    HGate,
+    SGate,
+    SdgGate,
+    CXGate,
+    CYGate,
+    CZGate,
+    SwapGate,
+)
+
+from qiskit_qec.circuits.code_circuit import CodeCircuit
+
+from stim import CircuitInstruction, CircuitRepeatBlock, target_inv
+
+from stim import Circuit as StimCircuit
+
+from qiskit_qec.utils.stim_tools import (
+    detector_error_model_to_rx_graph,
+    string2nodes_with_detectors,
+)
+
+class StimCodeCircuit(CodeCircuit):
+    """
+    Prepares a CodeCircuit class based on the supplied stim circuit.
+    """
+
+    def __init__(
+        self,
+        stim_circuit: StimCircuit,
+        barriers: bool = True,
+    ):
+        """
+        Args:
+            stim_circuit: stim circuit to be coverted
+            barriers (optional): whether to include barriers (coeersponding to stim TICK instructions)
+                in the qiskit circuits. Default is True
+        Examples:
+            Prepare and measure a Bell-state, checking the parity with a measurement comparison (DETECTOR)
+            >>> from qiskit_qec.circuits.stim_code_circuit import StimCodeCircuit
+            >>> stim_ex1 = stim.Circuit('''
+            >>>     H 0
+            >>>     TICK
+            >>>     CX 0 1
+            >>>     X_ERROR(0.2) 0 1
+            >>>     TICK
+            >>>     M 0 1
+            >>>     DETECTOR rec[-1] rec[-2]
+            >>> ''')
+            >>> stim_code = StimCodeCircuit(stim_circuit = stim_ex1)
+            >>> stim_code.qc
+        """
+        super().__init__()
+        self.stim_circuit = stim_circuit
+
+        self.measurement_data = []
+        self.detectors = []
+        self.logicals = []
+
+        self.qc = QuantumCircuit()
+        self.qc.add_register(QuantumRegister(self.stim_circuit.num_qubits))
+
+        single_qubit_gate_dict = {
+            "I": IGate(),
+            "X": XGate(),
+            "Y": YGate(),
+            "Z": ZGate(),
+            "H": HGate(),
+            "S": SGate(),
+            "S_DAG": SdgGate(),
+        }
+
+        two_qubit_gate_dict = {
+            "CX": CXGate(),
+            "CY": CYGate(),
+            "CZ": CZGate(),
+            "SWAP": SwapGate(),
+        }
+
+        def _helper(stim_circuit: StimCircuit, reps: int):
+            nonlocal rep_block_count
+            nonlocal block_count
+            for rep_ind in range(reps):
+                meas_count = 0
+                for instruction in stim_circuit:
+                    if isinstance(instruction, CircuitRepeatBlock):
+                        _helper(instruction.body_copy(), instruction.repeat_count)
+                        rep_block_count += 1
+                    elif isinstance(instruction, CircuitInstruction):
+                        inst_name = instruction.name
+                        if inst_name == "QUBIT_COORDS":
+                            m = 1
+                        elif inst_name in single_qubit_gate_dict.keys():
+                            qubits = [
+                                target.value for target in instruction.targets_copy()
+                            ]
+                            for q in qubits:
+                                self.qc.append(
+                                    single_qubit_gate_dict[inst_name], qargs=[q]
+                                )
+                        elif inst_name in two_qubit_gate_dict.keys():
+                            stim_targets = instruction.targets_copy()
+                            for t1, t2 in zip(stim_targets[::2], stim_targets[1::2]):
+                                if t1.is_qubit_target:
+                                    q1, q2 = t1.value, t2.value
+                                    self.qc.append(
+                                        two_qubit_gate_dict[inst_name], qargs=[q1, q2]
+                                    )
+                                elif t1.is_measurement_record_target:
+                                    c1, q2 = t1.value, t2.value
+                                    inst_name = inst_name[
+                                        1:
+                                    ]  # remove the C from CX,CY,CZ
+                                    self.qc.append(
+                                        single_qubit_gate_dict[inst_name], qargs=[q2]
+                                    ).c_if(c1, 1)
+
+                        elif inst_name == "M":
+                            qubits = [
+                                target.value for target in instruction.targets_copy()
+                            ]
+                            invert_result = [
+                                target.is_inverted_result_target
+                                for target in instruction.targets_copy()
+                            ]
+                            if reps > 1:
+                                cl_reg_name = (
+                                    "rep_block_"
+                                    + str(rep_block_count)
+                                    + "_rep_"
+                                    + str(rep_ind)
+                                    + "_meas_block_"
+                                    + str(meas_count)
+                                )
+                            else:
+                                cl_reg_name = (
+                                    "block_"
+                                    + str(rep_block_count)
+                                    + "_meas_block_"
+                                    + str(meas_count)
+                                )
+                            creg = ClassicalRegister(len(qubits), name=cl_reg_name)
+                            self.qc.add_register(creg)
+                            flip_qubits = [
+                                q for q, inv in zip(qubits, invert_result) if inv
+                            ]
+                            if flip_qubits != []:
+                                self.qc.x(flip_qubits)
+                            self.qc.measure(qubits, creg)
+                            for i, q in enumerate(qubits):
+                                self.measurement_data.append((cl_reg_name, i))
+                            if flip_qubits != []:
+                                self.qc.x(flip_qubits)
+                            meas_count += 1
+                        elif inst_name == "R":
+                            qubits = [
+                                target.value for target in instruction.targets_copy()
+                            ]
+                            self.qc.reset(qubits)
+
+                        elif inst_name == "TICK" and barriers:
+                            self.qc.barrier()
+
+                        elif inst_name == "DETECTOR":
+                            meas_targets = [t.value for t in instruction.targets_copy()]
+                            self.detectors.append(
+                                {
+                                    "clbits": [
+                                        self.measurement_data[ind]
+                                        for ind in meas_targets
+                                    ],
+                                    "time": [],
+                                    "qubits": [],
+                                    "stim_coords": instruction.gate_args_copy(),
+                                }
+                            )
+                        elif inst_name == "OBSERVABLE_INCLUDE":
+                            meas_targets = [t.value for t in instruction.targets_copy()]
+                            self.logicals.append(
+                                {
+                                    "clbits": [
+                                        self.measurement_data[ind]
+                                        for ind in meas_targets
+                                    ]
+                                }
+                            )
+
+        rep_block_count = 0
+        block_count = 0
+        self.decomp_stim_circuit = self.decompose_stim_circuit(self.stim_circuit)
+        _helper(self.decomp_stim_circuit, 1)
+
+        self.circuit = self.qc
+
+        # if a set of measurement comparisons is deterministically 1 in the absence of errors, the set of syndromes is compared to that
+        noiseless_measurements = self.decomp_stim_circuit.compile_sampler().sample(1)[0]
+        clbit_dict = {
+            (clbit._register.name, clbit._index): clind
+            for clind, clbit in enumerate(self.qc.clbits)
+        }
+        detector_meas_indices = [
+            [clbit_dict[clbit] for clbit in det["clbits"]] for det in self.detectors
+        ]
+        self.det_ref_values = [
+            sum(noiseless_measurements[meas_list]) % 2
+            for meas_list in detector_meas_indices
+        ]
+
+        # further code parameters
+        try:
+            self.d = len(self.stim_circuit.shortest_graphlike_error())  # code distance
+        except:
+            self.d = 0
+        self.n = stim_circuit.num_qubits
+        # the number of rounds is not necessarily well-defined (Floquet codes etc.)
+
+        return None
+
+    def decompose_stim_circuit(self, stim_circuit):
+        """
+        Decompose gates in the stim circuit into Clifford gates that have an equivalent qiskit gate.
+        Errors are not included.
+        """
+        decompose_1_dict = {
+            # single-qubit gates
+            "C_XYZ": [("S_DAG", [0]), ("H", [0])],
+            "C_ZYX": [("H", [0]), ("S", [0])],
+            "H_XY": [("X", [0]), ("S", [0])],
+            "H_XZ": [("H", [0])],
+            "H_YZ": [("H", [0]), ("S", [0]), ("H", [0]), ("Z", [0])],
+            "SQRT_X": [("H", [0]), ("S", [0]), ("H", [0])],
+            "SQRT_X_DAG": [("S", [0]), ("H", [0]), ("S", [0])],
+            "SQRT_Y": [("Z", [0]), ("H", [0])],
+            "SQRT_Y_DAG": [("H", [0]), ("Z", [0])],
+            "SQRT_Z": [("S", [0])],
+            "SQRT_Z_DAG": [("S_DAG", [0])],
+        }
+
+        decompose_2_dict = {
+            # two-qubit gates
+            "CNOT": [("CX", [0, 1])],
+            "CXSWAP": [("CX", [0, 1]), ("SWAP", [0, 1])],
+            "SWAPCX": [("SWAP", [0, 1]), ("CX", [0, 1])],
+            "ISWAP": [
+                ("H", [0]),
+                ("SWAP", [0, 1]),
+                ("CX", [0, 1]),
+                ("S", [0]),
+                ("H", [1]),
+                ("S", [1]),
+            ],
+            "ISWAP_DAG": [
+                ("S_DAG", [0]),
+                ("S_DAG", [1]),
+                ("H", [1]),
+                ("CX", [0, 1]),
+                ("SWAP", [0, 1]),
+                ("H", [0]),
+            ],
+            "SQRT_XX": [
+                ("H", [0]),
+                ("CX", [0, 1]),
+                ("S", [0]),
+                ("H", [0]),
+                ("H", [1]),
+                ("S", [1]),
+                ("H", [1]),
+            ],
+            "SQRT_XX_DAG": [
+                ("H", [0]),
+                ("CX", [0, 1]),
+                ("S_DAG", [0]),
+                ("H", [0]),
+                ("H", [1]),
+                ("S_DAG", [1]),
+                ("H", [1]),
+            ],
+            "SQRT_YY": [
+                ("S_DAG", [0]),
+                ("H", [0]),
+                ("S_DAG", [1]),
+                ("CX", [0, 1]),
+                ("S", [0]),
+                ("H", [0]),
+                ("S", [0]),
+                ("H", [1]),
+                ("S", [1]),
+                ("H", [1]),
+                ("S", [1]),
+            ],
+            "SQRT_YY_DAG": [
+                ("S_DAG", [0]),
+                ("H", [0]),
+                ("S", [1]),
+                ("CX", [0, 1]),
+                ("S", [0]),
+                ("H", [0]),
+                ("S", [0]),
+                ("H", [1]),
+                ("S", [1]),
+                ("H", [1]),
+                ("S_DAG", [1]),
+            ],
+            "SQRT_ZZ": [("H", [1]), ("CX", [0, 1]), ("S", [0]), ("H", [1]), ("S", [1])],
+            "SQRT_ZZ_DAG": [
+                ("H", [1]),
+                ("CX", [0, 1]),
+                ("S_DAG", [0]),
+                ("H", [1]),
+                ("S_DAG", [1]),
+            ],
+            "XCX": [("H", [0]), ("CX", [0, 1]), ("H", [0])],
+            "XCY": [("H", [0]), ("CY", [0, 1]), ("H", [0])],
+            "XCZ": [("H", [0]), ("CZ", [0, 1]), ("S", [0])],
+            "YCX": [("S_DAG", [0]), ("H", [0]), ("CX", [0, 1]), ("H", [0]), ("S", [0])],
+            "YCY": [("S_DAG", [0]), ("H", [0]), ("CY", [0, 1]), ("H", [0]), ("S", [0])],
+            "YCZ": [("S_DAG", [0]), ("H", [0]), ("CZ", [0, 1]), ("H", [0]), ("S", [0])],
+            "ZCX": [("CX", [0, 1])],
+            "ZCY": [("CY", [0, 1])],
+            "ZCZ": [("CZ", [0, 1])],
+        }
+        decompose_m_dict = {
+            # measurements
+            "MX": [("H", [0]), ("M", [0]), ("H", [0])],
+            "MY": [
+                ("S_DAG", [0]),
+                ("H", [0]),
+                ("M", [0]),
+                ("H", [0]),
+                ("S", [0]),
+            ],
+            "MZ": [("M", [0])],
+            "RX": [("H", [0]), ("R", [0]), ("H", [0])],
+            "RY": [
+                ("S_DAG", [0]),
+                ("H", [0]),
+                ("R", [0]),
+                ("H", [0]),
+                ("S", [0]),
+            ],
+            "RZ": [("R", [0])],
+            "MRX": [("H", [0]), ("M", [0]), ("R", [0]), ("H", [0])],
+            "MRY": [
+                ("S_DAG", [0]),
+                ("H", [0]),
+                ("M", [0]),
+                ("R", [0]),
+                ("H", [0]),
+                ("S", [0]),
+            ],
+            "MRZ": [("M", [0]), ("R", [0])],
+            "MR": [("M", [0]), ("R", [0])],
+            "MXX": [("CX", [0, 1]), ("H", [0]), ("M", [0]), ("H", [0]), ("CX", [0, 1])],
+            "MYY": [
+                ("S_DAG", [0]),
+                ("S_DAG", [1]),
+                ("CX", [0, 1]),
+                ("H", [0]),
+                ("M", [0]),
+                ("H", [0]),
+                ("CX", [0, 1]),
+                ("S", [0]),
+                ("S", [1]),
+            ],
+            "MZZ": [("CX", [0, 1]), ("M", [1]), ("CX", [0, 1])],
+        }
+
+        stim_error_list = [
+            "CORRELATED_ERROR",
+            "DEPOLARIZE1",
+            "DEPOLARIZE2",
+            "E",
+            "ELSE_CORRELATED_ERROR",
+            "HERALDED_ERASE",
+            "HERALDED_PAULI_CHANNEL_1",
+            "PAULI_CHANNEL_1",
+            "PAULI_CHANNEL_2",
+            "X_ERROR",
+            "Y_ERROR",
+            "Z_ERROR",
+        ]
+
+        decomposed_stim_circuit = StimCircuit()
+        for instruction in stim_circuit:
+            if isinstance(instruction, CircuitInstruction):
+                if instruction.name in decompose_1_dict:
+                    targets = instruction.targets_copy()
+                    decomp_gate = StimCircuit()
+                    basis_gates = decompose_1_dict[instruction.name]
+                    for target in targets:
+                        for gate, _ in basis_gates:
+                            decomp_gate.append(gate, [target], [])
+                    decomposed_stim_circuit += decomp_gate
+                elif instruction.name in decompose_2_dict:
+                    targets = instruction.targets_copy()
+                    decomp_gate = StimCircuit()
+                    basis_gates = decompose_2_dict[instruction.name]
+                    for target_pair in zip(targets[::2], targets[1::2]):
+                        for gate, qubit_ind in basis_gates:
+                            qubits = [target_pair[qubit_ind[0]]]
+                            if len(qubit_ind) == 2:
+                                qubits.append(target_pair[qubit_ind[1]])
+                            decomp_gate.append(gate, qubits, [])
+                    decomposed_stim_circuit += decomp_gate
+                elif instruction.name in decompose_m_dict:
+                    arg = instruction.gate_args_copy()
+                    target_list = instruction.targets_copy()
+                    decomp_gate = StimCircuit()
+                    basis_gates = decompose_m_dict[instruction.name]
+                    if instruction.name in ("MXX", "MYY", "MZZ"):
+                        if len(set(target_list)) < len(
+                            target_list
+                        ):  # avoiding overlaps that result from stim broadcating
+                            target_list = [
+                                target_list[i : i + 2]
+                                for i in range(0, len(target_list), 2)
+                            ]
+                        else:
+                            target_list = [target_list]
+                        for targets in target_list:
+                            for gate, qubit_ind in basis_gates:
+                                if len(qubit_ind) == 2:
+                                    qubit_list = [
+                                        target_pair[q_ind].value
+                                        for target_pair in zip(
+                                            targets[::2], targets[1::2]
+                                        )
+                                        for q_ind in qubit_ind
+                                    ]
+                                else:
+                                    qubit_list = [
+                                        target_pair[qubit_ind[0]].value
+                                        for target_pair in zip(
+                                            targets[::2], targets[1::2]
+                                        )
+                                    ]
+
+                                if gate == "M":
+                                    inv_list = [
+                                        (
+                                            target_pair[0].is_inverted_result_target
+                                            + target_pair[1].is_inverted_result_target
+                                        )
+                                        % 2
+                                        for target_pair in zip(
+                                            targets[::2], targets[1::2]
+                                        )
+                                    ]
+                                    for i, inv in enumerate(inv_list):
+                                        if inv:
+                                            qubit_list[i] = target_inv(qubit_list[i])
+                                    decomp_gate.append(gate, qubit_list, arg)
+                                else:
+                                    decomp_gate.append(gate, qubit_list, [])
+
+                    else:
+                        for gate, _ in basis_gates:
+                            qubit_list = [target.value for target in target_list]
+                            if gate == "M":
+                                inv_list = [
+                                    target.is_inverted_result_target
+                                    for target in target_list
+                                ]
+                                for i, inv in enumerate(inv_list):
+                                    if inv:
+                                        qubit_list[i] = target_inv(qubit_list[i])
+                                decomp_gate.append(gate, qubit_list, arg)
+                            else:
+                                decomp_gate.append(gate, qubit_list, [])
+
+                    decomposed_stim_circuit += decomp_gate
+
+                elif instruction.name == "MPP":
+                    decomposed_stim_circuit += self.MPP_circuit(instruction)
+                elif instruction.name == "MPAD":
+                    """
+                    MPAD does affect the stim measurement sample output, but not the detector sample.
+                    This is due to the fact that detectors are sensitive to changes wrt. the perfect output,
+                    R 0
+                    MPAD 1
+                    M 0
+                    DETECTOR rec[-1] rec[-2]
+                    The above example results in a deterministinc detector samples False, not True!
+
+                    MPAD can have an effect on measurements, when a CX is controlled on an MPAD bit...
+                    but what is the point of that anyway?
+                    """
+                    warnings.warn(
+                        "The circuit contains MPAD instructions that are ignored in the conversion. This can affect the measurement outcomes, but not the detectors."
+                    )
+                    pass
+                elif instruction.name in stim_error_list:
+                    # do not include errors
+                    pass
+                else:
+                    gate = instruction.name
+                    arg = instruction.gate_args_copy()
+                    targets = instruction.targets_copy()
+                    decomposed_stim_circuit.append(gate, targets, arg)
+            elif isinstance(instruction, CircuitRepeatBlock):
+                decomposed_stim_circuit.append(
+                    CircuitRepeatBlock(
+                        instruction.repeat_count,
+                        self.decompose_stim_circuit(instruction.body_copy()),
+                    )
+                )
+
+        return decomposed_stim_circuit
+
+    def MPP_circuit(self, stim_instruction):
+        MPP_stim_circuit = StimCircuit()
+        arg = stim_instruction.gate_args_copy()
+
+        # break it down into individual Pauli products
+        target_lists = []
+        target_list = []
+        prev_is_combiner = True
+        for target in stim_instruction.targets_copy():
+            if prev_is_combiner:
+                target_list.append(target)
+                prev_is_combiner = False
+            elif target.is_combiner:
+                prev_is_combiner = True
+            else:
+                target_lists.append(target_list)
+                target_list = [target]
+                prev_is_combiner = False
+        target_lists.append(target_list)
+
+        for target_list in target_lists:
+            invert = 0
+            first_target_qubit = target_list[0].value
+            for target in target_list:
+                if target.is_x_target:
+                    MPP_stim_circuit.append("H", target.value)
+                elif target.is_y_target:
+                    MPP_stim_circuit.append("S_DAG", target.value)
+                    MPP_stim_circuit.append("H", target.value)
+                invert = (invert + target.is_inverted_result_target) % 2
+                if target.value != first_target_qubit:
+                    MPP_stim_circuit.append("CX", [target.value, first_target_qubit])
+            if invert:
+                MPP_stim_circuit.append("M", target_inv(first_target_qubit), arg)
+            else:
+                MPP_stim_circuit.append("M", first_target_qubit, arg)
+
+            for target in target_list[::-1]:
+                if target.value != first_target_qubit:
+                    MPP_stim_circuit.append("CX", [target.value, first_target_qubit])
+                if target.is_x_target:
+                    MPP_stim_circuit.append("H", target.value)
+                elif target.is_y_target:
+                    MPP_stim_circuit.append("H", target.value)
+                    MPP_stim_circuit.append("S", target.value)
+
+        return MPP_stim_circuit
+
+    def string2nodes(self, string, **kwargs):
+        """
+        Convert output string from circuits into a set of nodes for `DecodingGraph`.
+        Args:
+            string (string): Results string to convert.
+            kwargs (dict): Any additional keyword arguments.
+                logical (str): Logical value whose results are used ('0' as default).
+                all_logicals (bool): Whether to include logical nodes
+                irrespective of value. (False as default).
+        """
+
+        nodes = string2nodes_with_detectors(
+            string=string,
+            detectors=self.detectors,
+            logicals=self.logicals,
+            clbits=self.qc.clbits,
+            det_ref_values=self.det_ref_values,
+            **kwargs
+        )
+        return nodes
+
+    def _make_syndrome_graph(self):
+        e = self.stim_circuit.detector_error_model(
+            decompose_errors=True, approximate_disjoint_errors=True
+        )
+        graph, hyperedges = detector_error_model_to_rx_graph(
+            e, detectors=self.detectors
+        )
+        return graph, hyperedges
+
+    def check_nodes(self, nodes, ignore_extra_boundary=False, minimal=False):
+        raise NotImplementedError
+
+    def is_cluster_neutral(self, atypical_nodes):
+        raise NotImplementedError

--- a/src/qiskit_qec/circuits/stim_code_circuit.py
+++ b/src/qiskit_qec/circuits/stim_code_circuit.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+
+ # This code is part of Qiskit.
+ #
+ # (C) Copyright IBM 2023.
+ #
+ # This code is licensed under the Apache License, Version 2.0. You may
+ # obtain a copy of this license in the LICENSE.txt file in the root directory
+ # of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+ #
+ # Any modifications or derivative works of this code must retain this
+ # copyright notice, and modified files need to carry a notice indicating
+ # that they have been altered from the originals.
+
+ # pylint: disable=invalid-name, disable=no-name-in-module
+
+ """Generates code circuits classes for Stim circuits."""
+
 import warnings
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
@@ -16,12 +34,10 @@ from qiskit.circuit.library.standard_gates import (
     SwapGate,
 )
 
-from qiskit_qec.circuits.code_circuit import CodeCircuit
-
 from stim import CircuitInstruction, CircuitRepeatBlock, target_inv
-
 from stim import Circuit as StimCircuit
 
+from qiskit_qec.circuits.code_circuit import CodeCircuit
 from qiskit_qec.utils.stim_tools import (
     detector_error_model_to_rx_graph,
     string2nodes_with_detectors,
@@ -45,7 +61,8 @@ class StimCodeCircuit(CodeCircuit):
             barriers (optional): whether to include barriers (coeersponding to stim TICK instructions)
                 in the qiskit circuits. Default is True
         Examples:
-            Prepare and measure a Bell-state, checking the parity with a measurement comparison (DETECTOR)
+            Prepare and measure a Bell-state, checking the parity with a measurement
+            comparison (DETECTOR)
             >>> from qiskit_qec.circuits.stim_code_circuit import StimCodeCircuit
             >>> stim_ex1 = stim.Circuit('''
             >>>     H 0
@@ -99,11 +116,11 @@ class StimCodeCircuit(CodeCircuit):
                         inst_name = instruction.name
                         if inst_name == "QUBIT_COORDS":
                             m = 1
-                        elif inst_name in single_qubit_gate_dict.keys():
+                        elif inst_name in single_qubit_gate_dict:
                             qubits = [target.value for target in instruction.targets_copy()]
                             for q in qubits:
                                 self.qc.append(single_qubit_gate_dict[inst_name], qargs=[q])
-                        elif inst_name in two_qubit_gate_dict.keys():
+                        elif inst_name in two_qubit_gate_dict:
                             stim_targets = instruction.targets_copy()
                             for t1, t2 in zip(stim_targets[::2], stim_targets[1::2]):
                                 if t1.is_qubit_target:
@@ -179,7 +196,9 @@ class StimCodeCircuit(CodeCircuit):
 
         self.circuit = self.qc
 
-        # if a set of measurement comparisons is deterministically 1 in the absence of errors, the set of syndromes is compared to that
+
+        # if a set of measurement comparisons is deterministically 1 in the absence of errors,
+        # the set of syndromes is compared to that
         noiseless_measurements = self.decomp_stim_circuit.compile_sampler().sample(1)[0]
         clbit_dict = {
             (clbit._register.name, clbit._index): clind
@@ -199,8 +218,6 @@ class StimCodeCircuit(CodeCircuit):
             self.d = 0
         self.n = stim_circuit.num_qubits
         # the number of rounds is not necessarily well-defined (Floquet codes etc.)
-
-        return None
 
     def decompose_stim_circuit(self, stim_circuit):
         """
@@ -451,20 +468,20 @@ class StimCodeCircuit(CodeCircuit):
                 elif instruction.name == "MPP":
                     decomposed_stim_circuit += self.MPP_circuit(instruction)
                 elif instruction.name == "MPAD":
-                    """
-                    MPAD does affect the stim measurement sample output, but not the detector sample.
-                    This is due to the fact that detectors are sensitive to changes wrt. the perfect output,
-                    R 0
-                    MPAD 1
-                    M 0
-                    DETECTOR rec[-1] rec[-2]
-                    The above example results in a deterministinc detector samples False, not True!
-
-                    MPAD can have an effect on measurements, when a CX is controlled on an MPAD bit...
-                    but what is the point of that anyway?
-                    """
+                    # MPAD does affect the stim measurement sample output, but not the detector sample.
+                    # This is due to the fact that detectors are sensitive to changes
+                    # wrt the perfect output,
+                    # R 0
+                    # MPAD 1
+                    # M 0
+                    # DETECTOR rec[-1] rec[-2]
+                    # The above example results in a deterministinc detector samples False, not True!
+                    #
+                    # MPAD can have an effect on measurements, when a CX is controlled on an MPAD bit...
+                    # but what is the point of that anyway?
                     warnings.warn(
-                        "The circuit contains MPAD instructions that are ignored in the conversion. This can affect the measurement outcomes, but not the detectors."
+                        "The circuit contains MPAD instructions that are ignored in the conversion."
+                        "This can affect the measurement outcomes, but not the detectors."
                     )
                     pass
                 elif instruction.name in stim_error_list:
@@ -486,6 +503,7 @@ class StimCodeCircuit(CodeCircuit):
         return decomposed_stim_circuit
 
     def MPP_circuit(self, stim_instruction):
+        """Handle MPP measurements."""
         MPP_stim_circuit = StimCircuit()
         arg = stim_instruction.gate_args_copy()
 

--- a/src/qiskit_qec/circuits/stim_code_circuit.py
+++ b/src/qiskit_qec/circuits/stim_code_circuit.py
@@ -14,8 +14,6 @@
 
  # pylint: disable=invalid-name, disable=no-name-in-module
 
- """Generates code circuits classes for Stim circuits."""
-
 import warnings
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister

--- a/src/qiskit_qec/circuits/stim_code_circuit.py
+++ b/src/qiskit_qec/circuits/stim_code_circuit.py
@@ -25,6 +25,7 @@ from stim import Circuit as StimCircuit
 from qiskit_qec.utils.stim_tools import (
     detector_error_model_to_rx_graph,
     string2nodes_with_detectors,
+    string2logical_meas,
 )
 
 
@@ -553,6 +554,17 @@ class StimCodeCircuit(CodeCircuit):
         )
         return nodes
 
+    def string2raw_logicals(self,string):
+        """
+        Converts output string into a list of logical measurement outcomes
+        Logicals are the logical measurements produced by self.stim_detectors()
+        """
+        _,self.logicals = self.stim_detectors()
+        
+        log_outs = string2logical_meas(string, self.logicals,self.circuit.clbits)
+
+        return log_outs
+    
     def _make_syndrome_graph(self):
         e = self.stim_circuit.detector_error_model(
             decompose_errors=True, approximate_disjoint_errors=True

--- a/src/qiskit_qec/circuits/stim_code_circuit.py
+++ b/src/qiskit_qec/circuits/stim_code_circuit.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 
- # This code is part of Qiskit.
- #
- # (C) Copyright IBM 2023.
- #
- # This code is licensed under the Apache License, Version 2.0. You may
- # obtain a copy of this license in the LICENSE.txt file in the root directory
- # of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
- #
- # Any modifications or derivative works of this code must retain this
- # copyright notice, and modified files need to carry a notice indicating
- # that they have been altered from the originals.
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
- # pylint: disable=invalid-name, disable=no-name-in-module
+# pylint: disable=invalid-name, disable=no-name-in-module
 
 import warnings
 
@@ -193,7 +193,6 @@ class StimCodeCircuit(CodeCircuit):
         _helper(self.decomp_stim_circuit, 1)
 
         self.circuit = self.qc
-
 
         # if a set of measurement comparisons is deterministically 1 in the absence of errors,
         # the set of syndromes is compared to that
@@ -570,17 +569,17 @@ class StimCodeCircuit(CodeCircuit):
         )
         return nodes
 
-    def string2raw_logicals(self,string):
+    def string2raw_logicals(self, string):
         """
         Converts output string into a list of logical measurement outcomes
         Logicals are the logical measurements produced by self.stim_detectors()
         """
-        _,self.logicals = self.stim_detectors()
-        
-        log_outs = string2logical_meas(string, self.logicals,self.circuit.clbits)
+        _, self.logicals = self.stim_detectors()
+
+        log_outs = string2logical_meas(string, self.logicals, self.circuit.clbits)
 
         return log_outs
-    
+
     def _make_syndrome_graph(self):
         e = self.stim_circuit.detector_error_model(
             decompose_errors=True, approximate_disjoint_errors=True

--- a/src/qiskit_qec/circuits/surface_code.py
+++ b/src/qiskit_qec/circuits/surface_code.py
@@ -316,6 +316,13 @@ class SurfaceCodeCircuit(CodeCircuit):
 
         return syndrome_changes
 
+    def measured_logicals(self):
+        if self.basis == "x":
+            measured_logicals = self.css_x_logical
+        else:
+            measured_logicals = self.css_z_logical
+        return measured_logicals
+
     def string2raw_logicals(self, string):
         """
         Extracts raw logicals from output string.

--- a/src/qiskit_qec/decoders/hdrg_decoders.py
+++ b/src/qiskit_qec/decoders/hdrg_decoders.py
@@ -40,13 +40,8 @@ class ClusteringDecoder(ABC):
     ):
         self.code = code_circuit
 
-        if hasattr(self.code, "_xbasis"):
-            if self.code._xbasis:
-                self.measured_logicals = self.code.css_x_logical
-            else:
-                self.measured_logicals = self.code.css_z_logical
-        else:
-            self.measured_logicals = self.code.css_z_logical
+        self.measured_logicals = self.code.measured_logicals()
+
         if hasattr(self.code, "code_index"):
             self.code_index = self.code.code_index
         else:

--- a/src/qiskit_qec/utils/stim_tools.py
+++ b/src/qiskit_qec/utils/stim_tools.py
@@ -135,8 +135,7 @@ def get_stim_circuits(
                     prevc_offset += bit._register.size
 
             qubit_indices = [
-                qargs[i]._index + qreg_offset[qargs[i]._register.name]
-                for i in range(len(qargs))
+                qargs[i]._index + qreg_offset[qargs[i]._register.name] for i in range(len(qargs))
             ]
 
             if isinstance(inst, QuantumChannelInstruction):
@@ -146,29 +145,21 @@ def get_stim_circuits(
                 if pauli_errors_types[0][0]["name"] in pauli_error_1_stim_order:
                     probs = 4 * [0.0]
                     for pind, ptype in enumerate(pauli_errors_types):
-                        probs[pauli_error_1_stim_order[ptype[0]["name"]]] = pauli_probs[
-                            pind
-                        ]
+                        probs[pauli_error_1_stim_order[ptype[0]["name"]]] = pauli_probs[pind]
                     stim_circuit.append("PAULI_CHANNEL_1", qubit_indices, probs[1:])
                 elif pauli_errors_types[0][0]["params"][0] in pauli_error_2_stim_order:
                     # here the name is always 'pauli' and the params gives the Pauli type
                     probs = 16 * [0.0]
                     for pind, ptype in enumerate(pauli_errors_types):
-                        probs[
-                            pauli_error_2_stim_order[ptype[0]["params"][0]]
-                        ] = pauli_probs[pind]
+                        probs[pauli_error_2_stim_order[ptype[0]["params"][0]]] = pauli_probs[pind]
                     stim_circuit.append("PAULI_CHANNEL_2", qubit_indices, probs[1:])
                 else:
-                    raise Exception(
-                        "Unexpected operations: " + str([inst, qargs, cargs])
-                    )
+                    raise Exception("Unexpected operations: " + str([inst, qargs, cargs]))
             else:
                 # Gates and measurements
                 if inst.name in qiskit_to_stim_dict:
                     if len(cargs) > 0:  # keeping track of measurement indices in stim
-                        measurement_data.append(
-                            [cargs[0]._register.name, cargs[0]._index]
-                        )
+                        measurement_data.append([cargs[0]._register.name, cargs[0]._index])
 
                     if qiskit_to_stim_dict[inst.name] == "TICK":  # barrier
                         stim_circuit.append("TICK")
@@ -194,27 +185,19 @@ def get_stim_circuits(
                                 )
                         else:
                             raise Exception(
-                                "Classically controlled "
-                                + inst.name
-                                + " gate is not supported"
+                                "Classically controlled " + inst.name + " gate is not supported"
                             )
                     else:  # gates/measurements acting on qubits
-                        stim_circuit.append(
-                            qiskit_to_stim_dict[inst.name], qubit_indices
-                        )
+                        stim_circuit.append(qiskit_to_stim_dict[inst.name], qubit_indices)
                 else:
-                    raise Exception(
-                        "Unexpected operations: " + str([inst, qargs, cargs])
-                    )
+                    raise Exception("Unexpected operations: " + str([inst, qargs, cargs]))
 
         if detectors != [[]]:
             for det in detectors:
                 stim_record_targets = []
                 for reg, ind in det["clbits"]:
                     stim_record_targets.append(
-                        StimTarget_rec(
-                            measurement_data.index([reg, ind]) - len(measurement_data)
-                        )
+                        StimTarget_rec(measurement_data.index([reg, ind]) - len(measurement_data))
                     )
                 if det["time"] != []:
                     stim_circuit.append(
@@ -227,9 +210,7 @@ def get_stim_circuits(
                 stim_record_targets = []
                 for reg, ind in log["clbits"]:
                     stim_record_targets.append(
-                        StimTarget_rec(
-                            measurement_data.index([reg, ind]) - len(measurement_data)
-                        )
+                        StimTarget_rec(measurement_data.index([reg, ind]) - len(measurement_data))
                     )
                 stim_circuit.append("OBSERVABLE_INCLUDE", stim_record_targets, log_ind)
 
@@ -381,14 +362,10 @@ def detector_error_model_to_rx_graph(
 
     index_to_DecodingGraphNode = {}
 
-    def skip_error(
-        p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict
-    ):
+    def skip_error(p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict):
         pass
 
-    def handle_error(
-        p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict
-    ):
+    def handle_error(p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict):
         if p == 0:
             return
         if len(dets) == 0:
@@ -443,9 +420,7 @@ def detector_error_model_to_rx_graph(
         hyperedges=hyperedges,
     )
 
-    trivial_boundary_node = DecodingGraphNode(
-        index=model.num_detectors, time=0, is_boundary=True
-    )
+    trivial_boundary_node = DecodingGraphNode(index=model.num_detectors, time=0, is_boundary=True)
     g.add_node(trivial_boundary_node)
     index_to_DecodingGraphNode[model.num_detectors] = trivial_boundary_node
 
@@ -489,10 +464,7 @@ def string2nodes_with_detectors(
 
     # if all_logical:
 
-    clbit_dict = {
-        (clbit._register.name, clbit._index): clind
-        for clind, clbit in enumerate(clbits)
-    }
+    clbit_dict = {(clbit._register.name, clbit._index): clind for clind, clbit in enumerate(clbits)}
 
     if isinstance(det_ref_values, int):
         det_ref_values = [det_ref_values] * len(detectors)
@@ -502,9 +474,7 @@ def string2nodes_with_detectors(
         det = det.copy()
         outcomes = [clbit_dict[clbit_key] for clbit_key in det.pop("clbits")]
         if sum(output_bits[outcomes]) % 2 != det_ref_values[ind]:
-            node = DecodingGraphNode(
-                time=det.pop("time"), qubits=det.pop("qubits"), index=ind
-            )
+            node = DecodingGraphNode(time=det.pop("time"), qubits=det.pop("qubits"), index=ind)
             node.properties = det
             nodes.append(node)
 
@@ -527,9 +497,7 @@ def string2nodes_with_detectors(
     return nodes
 
 
-def noisify_circuit(
-    circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel
-):
+def noisify_circuit(circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel):
     """
     Inserts error operations into a circuit according to a pauli noise model.
     Handles idling errors in the form of custom gates "idle_#" which are assumed to

--- a/src/qiskit_qec/utils/stim_tools.py
+++ b/src/qiskit_qec/utils/stim_tools.py
@@ -45,6 +45,7 @@ def get_stim_circuits(
     """Converts compatible qiskit circuits to stim circuits.
        Dictionaries are not complete. For the stim definitions see:
        https://github.com/quantumlib/Stim/blob/main/doc/gates.md
+
     Args:
         circuit: Compatible gates are Paulis, controlled Paulis, h, s,
         and sdg, swap, reset, measure and barrier. Compatible noise operators

--- a/src/qiskit_qec/utils/stim_tools.py
+++ b/src/qiskit_qec/utils/stim_tools.py
@@ -532,6 +532,7 @@ def string2rawlogicals_with_detectors(
 
     return nodes
 
+
 def string2logical_meas(
     string: str,
     outcomes_in_logical: List[Dict],
@@ -540,17 +541,14 @@ def string2logical_meas(
     """
     Args:
         string (string): Results string from qiskit circuit
-        outcomes_in_logical: 
-        clbits: classical bits of the qiskit circuit, needed to identify 
+        outcomes_in_logical: the detector-style logical outcome
+        clbits: classical bits of the qiskit circuit, needed to identify
         measurements in the output string
     """
 
     output_bits = np.array([int(char) for char in string.replace(" ", "")[::-1]])
 
-    clbit_dict = {
-        (clbit._register.name, clbit._index): clind
-        for clind, clbit in enumerate(clbits)
-    }
+    clbit_dict = {(clbit._register.name, clbit._index): clind for clind, clbit in enumerate(clbits)}
 
     log_outs = []
     for logical_op in outcomes_in_logical:
@@ -560,13 +558,11 @@ def string2logical_meas(
             logical_out += output_bits[qind]
         logical_out = logical_out % 2
         log_outs.append(logical_out)
-    
+
     return log_outs
 
 
-def noisify_circuit(
-    circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel
-):
+def noisify_circuit(circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel):
     """
     Inserts error operations into a circuit according to a pauli noise model.
     Handles idling errors in the form of custom gates "idle_#" which are assumed to

--- a/src/qiskit_qec/utils/stim_tools.py
+++ b/src/qiskit_qec/utils/stim_tools.py
@@ -30,14 +30,18 @@ import rustworkx as rx
 from qiskit import QuantumCircuit
 from qiskit_aer.noise.errors.quantum_error import QuantumChannelInstruction
 from qiskit_aer.noise import pauli_error
-from qiskit_qec.utils.decoding_graph_attributes import DecodingGraphNode, DecodingGraphEdge
+from qiskit_qec.utils.decoding_graph_attributes import (
+    DecodingGraphNode,
+    DecodingGraphEdge,
+)
 from qiskit_qec.noise.paulinoisemodel import PauliNoiseModel
 
 
-def get_stim_circuits(circuit: Union[QuantumCircuit, List], 
-                      detectors: Union[List[Dict],List[List]] = [[]], 
-                      logicals: Union[List[Dict],List[List]] = [[]]
-                      ):
+def get_stim_circuits(
+    circuit: Union[QuantumCircuit, List],
+    detectors: Union[List[Dict], List[List]] = [[]],
+    logicals: Union[List[Dict], List[List]] = [[]],
+):
     """Converts compatible qiskit circuits to stim circuits.
        Dictionaries are not complete. For the stim definitions see:
        https://github.com/quantumlib/Stim/blob/main/doc/gates.md
@@ -45,23 +49,23 @@ def get_stim_circuits(circuit: Union[QuantumCircuit, List],
         circuit: Compatible gates are Paulis, controlled Paulis, h, s,
         and sdg, swap, reset, measure and barrier. Compatible noise operators
         correspond to a single or two qubit pauli channel.
-        detectors: A list of measurement comparisons. A measurement comparison 
-        (detector) is either a list of measurements given by a the name and index 
-        of the classical bit or a list of dictionaries, with a mandatory clbits 
-        key containing the classical bits. A dictionary can contain keys like 
+        detectors: A list of measurement comparisons. A measurement comparison
+        (detector) is either a list of measurements given by a the name and index
+        of the classical bit or a list of dictionaries, with a mandatory clbits
+        key containing the classical bits. A dictionary can contain keys like
         'qubits', 'time', 'basis' etc.
-        logicals: A list of logical measurements. A logical measurement is a 
+        logicals: A list of logical measurements. A logical measurement is a
         list of classical bits whose total parity is the logical eigenvalue.
         Again it can be a list of dictionaries.
 
     Returns:
         stim_circuits, stim_measurement_data
     """
-    if len(detectors)>0 and isinstance(detectors[0],List):
-        detectors = [{'clbits': det, 'qubits': [], 'time': 0} for det in detectors]
+    if len(detectors) > 0 and isinstance(detectors[0], List):
+        detectors = [{"clbits": det, "qubits": [], "time": 0} for det in detectors]
 
-    if len(logicals)>0 and isinstance(logicals[0],List):
-        logicals = [{'clbits': log} for log in logicals]
+    if len(logicals) > 0 and isinstance(logicals[0], List):
+        logicals = [{"clbits": log} for log in logicals]
 
     stim_circuits = []
     stim_measurement_data = []
@@ -94,7 +98,7 @@ def get_stim_circuits(circuit: Union[QuantumCircuit, List],
             "Y": 2,
             "y": 2,
             "Z": 3,
-            "z": 3
+            "z": 3,
         }
         pauli_error_2_stim_order = {
             "II": 0,
@@ -142,79 +146,103 @@ def get_stim_circuits(circuit: Union[QuantumCircuit, List],
                 if pauli_errors_types[0][0]["name"] in pauli_error_1_stim_order:
                     probs = 4 * [0.0]
                     for pind, ptype in enumerate(pauli_errors_types):
-                        probs[pauli_error_1_stim_order[ptype[0]["name"]]] = pauli_probs[pind]
+                        probs[pauli_error_1_stim_order[ptype[0]["name"]]] = pauli_probs[
+                            pind
+                        ]
                     stim_circuit.append("PAULI_CHANNEL_1", qubit_indices, probs[1:])
                 elif pauli_errors_types[0][0]["params"][0] in pauli_error_2_stim_order:
                     # here the name is always 'pauli' and the params gives the Pauli type
                     probs = 16 * [0.0]
                     for pind, ptype in enumerate(pauli_errors_types):
-                        probs[pauli_error_2_stim_order[ptype[0]["params"][0]]] = pauli_probs[pind]
+                        probs[
+                            pauli_error_2_stim_order[ptype[0]["params"][0]]
+                        ] = pauli_probs[pind]
                     stim_circuit.append("PAULI_CHANNEL_2", qubit_indices, probs[1:])
                 else:
-                    raise Exception("Unexpected operations: " + str([inst, qargs, cargs]))
+                    raise Exception(
+                        "Unexpected operations: " + str([inst, qargs, cargs])
+                    )
             else:
                 # Gates and measurements
                 if inst.name in qiskit_to_stim_dict:
                     if len(cargs) > 0:  # keeping track of measurement indices in stim
                         measurement_data.append(
-                            [
-                                cargs[0]._register.name,
-                                cargs[0]._index
-                            ]
+                            [cargs[0]._register.name, cargs[0]._index]
                         )
-                    
+
                     if qiskit_to_stim_dict[inst.name] == "TICK":  # barrier
                         stim_circuit.append("TICK")
-                    elif inst.condition != None: #handle c_ifs
+                    elif inst.condition != None:  # handle c_ifs
                         if inst.name in "xyz":
                             if inst.condition[1] == 1:
                                 clbit = inst.condition[0]
-                                stim_circuit.append(qiskit_to_stim_dict["c"+inst.name], 
-                                                    [
-                                                        StimTarget_rec(
-                                                            measurement_data.index(
-                                                                [
-                                                                    clbit._register.name,                                                                    
-                                                                    clbit._index
-                                                                ]
-                                                            ) - len(measurement_data)
-                                                        ),
-                                                        qubit_indices[0]
-                                                    ]
-                                                    )
+                                stim_circuit.append(
+                                    qiskit_to_stim_dict["c" + inst.name],
+                                    [
+                                        StimTarget_rec(
+                                            measurement_data.index(
+                                                [clbit._register.name, clbit._index]
+                                            )
+                                            - len(measurement_data)
+                                        ),
+                                        qubit_indices[0],
+                                    ],
+                                )
                             else:
-                                raise Exception("Classically controlled gate must be conditioned on bit value 1")    
+                                raise Exception(
+                                    "Classically controlled gate must be conditioned on bit value 1"
+                                )
                         else:
-                            raise Exception("Classically controlled " + inst.name +" gate is not supported")
+                            raise Exception(
+                                "Classically controlled "
+                                + inst.name
+                                + " gate is not supported"
+                            )
                     else:  # gates/measurements acting on qubits
-                        stim_circuit.append(qiskit_to_stim_dict[inst.name], qubit_indices)
+                        stim_circuit.append(
+                            qiskit_to_stim_dict[inst.name], qubit_indices
+                        )
                 else:
-                    raise Exception("Unexpected operations: " + str([inst, qargs, cargs]))
+                    raise Exception(
+                        "Unexpected operations: " + str([inst, qargs, cargs])
+                    )
 
-        if detectors!=[[]]:
+        if detectors != [[]]:
             for det in detectors:
                 stim_record_targets = []
-                for reg,ind in det['clbits']:
-                    stim_record_targets.append(StimTarget_rec(measurement_data.index([reg,ind])-len(measurement_data)))
-                if det['time']!=[]:
-                    stim_circuit.append("DETECTOR", stim_record_targets, det['qubits']+[det['time']])
+                for reg, ind in det["clbits"]:
+                    stim_record_targets.append(
+                        StimTarget_rec(
+                            measurement_data.index([reg, ind]) - len(measurement_data)
+                        )
+                    )
+                if det["time"] != []:
+                    stim_circuit.append(
+                        "DETECTOR", stim_record_targets, det["qubits"] + [det["time"]]
+                    )
                 else:
                     stim_circuit.append("DETECTOR", stim_record_targets, [])
-        if logicals!=[[]]:
-            for log_ind,log in enumerate(logicals):
+        if logicals != [[]]:
+            for log_ind, log in enumerate(logicals):
                 stim_record_targets = []
-                for reg,ind in log['clbits']:
-                    stim_record_targets.append(StimTarget_rec(measurement_data.index([reg,ind])-len(measurement_data)))
+                for reg, ind in log["clbits"]:
+                    stim_record_targets.append(
+                        StimTarget_rec(
+                            measurement_data.index([reg, ind]) - len(measurement_data)
+                        )
+                    )
                 stim_circuit.append("OBSERVABLE_INCLUDE", stim_record_targets, log_ind)
-        
+
         stim_circuits.append(stim_circuit)
         stim_measurement_data.append(measurement_data)
 
-
     return stim_circuits, stim_measurement_data
 
+
 def get_counts_via_stim(
-    circuits: Union[List, QuantumCircuit], shots: int = 4000, noise_model: PauliNoiseModel = None
+    circuits: Union[List, QuantumCircuit],
+    shots: int = 4000,
+    noise_model: PauliNoiseModel = None,
 ):
     """Returns a qiskit compatible dictionary of measurement outcomes
 
@@ -262,16 +290,21 @@ def get_counts_via_stim(
 
     return counts
 
-def iter_flatten_model(model: StimDetectorErrorModel,
-                    handle_error: Callable[[float, List[int], List[int]], None],
-                    handle_detector_coords: Callable[[int, np.ndarray], None],
-                    detectors: List[Dict], hyperedges: List[Dict]):
+
+def iter_flatten_model(
+    model: StimDetectorErrorModel,
+    handle_error: Callable[[float, List[int], List[int]], None],
+    handle_detector_coords: Callable[[int, np.ndarray], None],
+    detectors: List[Dict],
+    hyperedges: List[Dict],
+):
     """
-        This function have been copied from the built-in method of
-        stim: stim.Circuit.generated("surface_code:rotated_memory_z",...)
+    This function have been copied from the built-in method of
+    stim: stim.Circuit.generated("surface_code:rotated_memory_z",...)
     """
 
     det_offset = 0
+
     def _helper(m: StimDetectorErrorModel, reps: int):
         nonlocal det_offset
         for _ in range(reps):
@@ -311,27 +344,36 @@ def iter_flatten_model(model: StimDetectorErrorModel,
                             det = {}
                         else:
                             det = detectors[det_ind].copy()
-                            time = det.pop('time')
-                            qubits = det.pop('qubits')
-                            del det['clbits']
+                            time = det.pop("time")
+                            qubits = det.pop("qubits")
+                            del det["clbits"]
                         for t in instruction.targets_copy():
-                            handle_detector_coords(detector_index=det_ind, time=time,qubits=qubits, det_props = det)
+                            handle_detector_coords(
+                                detector_index=det_ind,
+                                time=time,
+                                qubits=qubits,
+                                det_props=det,
+                            )
                     elif instruction.type == "logical_observable":
                         pass
                     else:
                         raise NotImplementedError()
                 else:
                     raise NotImplementedError()
+
     _helper(model, 1)
 
-def detector_error_model_to_rx_graph(model: StimDetectorErrorModel, detectors: List[Dict] = [{}]) -> rx.PyGraph:
+
+def detector_error_model_to_rx_graph(
+    model: StimDetectorErrorModel, detectors: List[Dict] = [{}]
+) -> rx.PyGraph:
     """Convert a stim error model into a RustworkX graph.
     It assumes that the stim circuit does not contain repeat blocks.
     Later on repeat blocks should be handled to make this function compatible with
     user-defined stim circuits.
 
-    Args: 
-        detector_qubits_time: if specified, supply a list of qubits with a time 
+    Args:
+        detector_qubits_time: if specified, supply a list of qubits with a time
         coordinate included as the last element for every detector in the stim detector error model
     """
 
@@ -339,10 +381,14 @@ def detector_error_model_to_rx_graph(model: StimDetectorErrorModel, detectors: L
 
     index_to_DecodingGraphNode = {}
 
-    def skip_error(p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict):
+    def skip_error(
+        p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict
+    ):
         pass
 
-    def handle_error(p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict):
+    def handle_error(
+        p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict
+    ):
         if p == 0:
             return
         if len(dets) == 0:
@@ -389,21 +435,39 @@ def detector_error_model_to_rx_graph(model: StimDetectorErrorModel, detectors: L
 
     hyperedges = []
 
-    iter_flatten_model(model, handle_error=skip_error, handle_detector_coords=handle_detector_coords,
-                       detectors=detectors, hyperedges=hyperedges)
+    iter_flatten_model(
+        model,
+        handle_error=skip_error,
+        handle_detector_coords=handle_detector_coords,
+        detectors=detectors,
+        hyperedges=hyperedges,
+    )
 
-    trivial_boundary_node = DecodingGraphNode(index=model.num_detectors, time=0, is_boundary=True)
+    trivial_boundary_node = DecodingGraphNode(
+        index=model.num_detectors, time=0, is_boundary=True
+    )
     g.add_node(trivial_boundary_node)
     index_to_DecodingGraphNode[model.num_detectors] = trivial_boundary_node
 
-    iter_flatten_model(model, handle_error=handle_error, handle_detector_coords=skip_detector_coords,
-                       detectors=detectors, hyperedges=hyperedges)
+    iter_flatten_model(
+        model,
+        handle_error=handle_error,
+        handle_detector_coords=skip_detector_coords,
+        detectors=detectors,
+        hyperedges=hyperedges,
+    )
 
     return g, hyperedges
 
 
-def string2nodes_with_detectors(string: str, detectors: List[Dict], logicals: List[Dict],
-                                clbits: QuantumCircuit.clbits, det_ref_values: Union[List,int] = 0, **kwargs):
+def string2nodes_with_detectors(
+    string: str,
+    detectors: List[Dict],
+    logicals: List[Dict],
+    clbits: QuantumCircuit.clbits,
+    det_ref_values: Union[List, int] = 0,
+    **kwargs,
+):
     """
     Convert output string from circuits into a set of nodes for
     `DecodingGraph`.
@@ -421,27 +485,32 @@ def string2nodes_with_detectors(string: str, detectors: List[Dict], logicals: Li
     if logical is None:
         logical = "0"
 
-    output_bits = np.array([int(char) for char in string.replace(" ","")[::-1]])
+    output_bits = np.array([int(char) for char in string.replace(" ", "")[::-1]])
 
     # if all_logical:
 
-    clbit_dict = {(clbit._register.name,clbit._index):clind for clind,clbit in enumerate(clbits)}
+    clbit_dict = {
+        (clbit._register.name, clbit._index): clind
+        for clind, clbit in enumerate(clbits)
+    }
 
-    if isinstance(det_ref_values,int):
-        det_ref_values=[det_ref_values]*len(detectors)
+    if isinstance(det_ref_values, int):
+        det_ref_values = [det_ref_values] * len(detectors)
 
     nodes = []
-    for ind,det in enumerate(detectors):
+    for ind, det in enumerate(detectors):
         det = det.copy()
-        outcomes = [clbit_dict[clbit_key] for clbit_key in det.pop('clbits')]
-        if sum(output_bits[outcomes])%2!=det_ref_values[ind]:
-            node = DecodingGraphNode(time=det.pop('time'), qubits=det.pop('qubits'), index=ind)
+        outcomes = [clbit_dict[clbit_key] for clbit_key in det.pop("clbits")]
+        if sum(output_bits[outcomes]) % 2 != det_ref_values[ind]:
+            node = DecodingGraphNode(
+                time=det.pop("time"), qubits=det.pop("qubits"), index=ind
+            )
             node.properties = det
             nodes.append(node)
 
-    for index, logical_op in enumerate(logicals,start=len(detectors)):
+    for index, logical_op in enumerate(logicals, start=len(detectors)):
         logical_out = 0
-        for q in logical_op['clbits']:
+        for q in logical_op["clbits"]:
             qind = clbit_dict[q]
             logical_out += output_bits[qind]
         logical_out = logical_out % 2
@@ -454,13 +523,16 @@ def string2nodes_with_detectors(string: str, detectors: List[Dict], logicals: Li
             )
             # node.properties["basis"] = self.basis
             nodes.append(node)
-            
+
     return nodes
 
-def noisify_circuit(circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel):
+
+def noisify_circuit(
+    circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel
+):
     """
     Inserts error operations into a circuit according to a pauli noise model.
-    Handles idling errors in the form of custom gates "idle_#" which are assumed to 
+    Handles idling errors in the form of custom gates "idle_#" which are assumed to
     encode the identity gate only.
     qc = QuantumCircuit(1, name='idle_1')
     qc.i(0)
@@ -481,9 +553,9 @@ def noisify_circuit(circuits: Union[List, QuantumCircuit], noise_model: PauliNoi
     # create pauli errors for all errors in noise model
     errors = {}
     for g, noise in noise_model.to_dict().items():
-        paulis = [pauli.upper() for pauli in noise['chan'].keys()]
-        probs = list(noise['chan'].values())
-        errors[g] = pauli_error(list(zip(paulis,probs)))
+        paulis = [pauli.upper() for pauli in noise["chan"].keys()]
+        probs = list(noise["chan"].values())
+        errors[g] = pauli_error(list(zip(paulis, probs)))
 
     noisy_circuits = []
     for qc in circuits:

--- a/src/qiskit_qec/utils/stim_tools.py
+++ b/src/qiskit_qec/utils/stim_tools.py
@@ -135,7 +135,8 @@ def get_stim_circuits(
                     prevc_offset += bit._register.size
 
             qubit_indices = [
-                qargs[i]._index + qreg_offset[qargs[i]._register.name] for i in range(len(qargs))
+                qargs[i]._index + qreg_offset[qargs[i]._register.name]
+                for i in range(len(qargs))
             ]
 
             if isinstance(inst, QuantumChannelInstruction):
@@ -145,21 +146,29 @@ def get_stim_circuits(
                 if pauli_errors_types[0][0]["name"] in pauli_error_1_stim_order:
                     probs = 4 * [0.0]
                     for pind, ptype in enumerate(pauli_errors_types):
-                        probs[pauli_error_1_stim_order[ptype[0]["name"]]] = pauli_probs[pind]
+                        probs[pauli_error_1_stim_order[ptype[0]["name"]]] = pauli_probs[
+                            pind
+                        ]
                     stim_circuit.append("PAULI_CHANNEL_1", qubit_indices, probs[1:])
                 elif pauli_errors_types[0][0]["params"][0] in pauli_error_2_stim_order:
                     # here the name is always 'pauli' and the params gives the Pauli type
                     probs = 16 * [0.0]
                     for pind, ptype in enumerate(pauli_errors_types):
-                        probs[pauli_error_2_stim_order[ptype[0]["params"][0]]] = pauli_probs[pind]
+                        probs[
+                            pauli_error_2_stim_order[ptype[0]["params"][0]]
+                        ] = pauli_probs[pind]
                     stim_circuit.append("PAULI_CHANNEL_2", qubit_indices, probs[1:])
                 else:
-                    raise Exception("Unexpected operations: " + str([inst, qargs, cargs]))
+                    raise Exception(
+                        "Unexpected operations: " + str([inst, qargs, cargs])
+                    )
             else:
                 # Gates and measurements
                 if inst.name in qiskit_to_stim_dict:
                     if len(cargs) > 0:  # keeping track of measurement indices in stim
-                        measurement_data.append([cargs[0]._register.name, cargs[0]._index])
+                        measurement_data.append(
+                            [cargs[0]._register.name, cargs[0]._index]
+                        )
 
                     if qiskit_to_stim_dict[inst.name] == "TICK":  # barrier
                         stim_circuit.append("TICK")
@@ -185,19 +194,27 @@ def get_stim_circuits(
                                 )
                         else:
                             raise Exception(
-                                "Classically controlled " + inst.name + " gate is not supported"
+                                "Classically controlled "
+                                + inst.name
+                                + " gate is not supported"
                             )
                     else:  # gates/measurements acting on qubits
-                        stim_circuit.append(qiskit_to_stim_dict[inst.name], qubit_indices)
+                        stim_circuit.append(
+                            qiskit_to_stim_dict[inst.name], qubit_indices
+                        )
                 else:
-                    raise Exception("Unexpected operations: " + str([inst, qargs, cargs]))
+                    raise Exception(
+                        "Unexpected operations: " + str([inst, qargs, cargs])
+                    )
 
         if detectors != [[]]:
             for det in detectors:
                 stim_record_targets = []
                 for reg, ind in det["clbits"]:
                     stim_record_targets.append(
-                        StimTarget_rec(measurement_data.index([reg, ind]) - len(measurement_data))
+                        StimTarget_rec(
+                            measurement_data.index([reg, ind]) - len(measurement_data)
+                        )
                     )
                 if det["time"] != []:
                     stim_circuit.append(
@@ -210,7 +227,9 @@ def get_stim_circuits(
                 stim_record_targets = []
                 for reg, ind in log["clbits"]:
                     stim_record_targets.append(
-                        StimTarget_rec(measurement_data.index([reg, ind]) - len(measurement_data))
+                        StimTarget_rec(
+                            measurement_data.index([reg, ind]) - len(measurement_data)
+                        )
                     )
                 stim_circuit.append("OBSERVABLE_INCLUDE", stim_record_targets, log_ind)
 
@@ -362,10 +381,14 @@ def detector_error_model_to_rx_graph(
 
     index_to_DecodingGraphNode = {}
 
-    def skip_error(p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict):
+    def skip_error(
+        p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict
+    ):
         pass
 
-    def handle_error(p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict):
+    def handle_error(
+        p: float, dets: List[int], frame_changes: List[int], hyperedge: Dict
+    ):
         if p == 0:
             return
         if len(dets) == 0:
@@ -420,7 +443,9 @@ def detector_error_model_to_rx_graph(
         hyperedges=hyperedges,
     )
 
-    trivial_boundary_node = DecodingGraphNode(index=model.num_detectors, time=0, is_boundary=True)
+    trivial_boundary_node = DecodingGraphNode(
+        index=model.num_detectors, time=0, is_boundary=True
+    )
     g.add_node(trivial_boundary_node)
     index_to_DecodingGraphNode[model.num_detectors] = trivial_boundary_node
 
@@ -455,16 +480,13 @@ def string2nodes_with_detectors(
             all_logicals (bool): Whether to include logical nodes
             irrespective of value. (False as default).
     """
-    all_logicals = kwargs.get("all_logicals")
-    logical = kwargs.get("logical")
-    if logical is None:
-        logical = "0"
 
     output_bits = np.array([int(char) for char in string.replace(" ", "")[::-1]])
 
-    # if all_logical:
-
-    clbit_dict = {(clbit._register.name, clbit._index): clind for clind, clbit in enumerate(clbits)}
+    clbit_dict = {
+        (clbit._register.name, clbit._index): clind
+        for clind, clbit in enumerate(clbits)
+    }
 
     if isinstance(det_ref_values, int):
         det_ref_values = [det_ref_values] * len(detectors)
@@ -474,11 +496,46 @@ def string2nodes_with_detectors(
         det = det.copy()
         outcomes = [clbit_dict[clbit_key] for clbit_key in det.pop("clbits")]
         if sum(output_bits[outcomes]) % 2 != det_ref_values[ind]:
-            node = DecodingGraphNode(time=det.pop("time"), qubits=det.pop("qubits"), index=ind)
+            node = DecodingGraphNode(
+                time=det.pop("time"), qubits=det.pop("qubits"), index=ind
+            )
             node.properties = det
             nodes.append(node)
 
-    for index, logical_op in enumerate(logicals, start=len(detectors)):
+    log_nodes = string2rawlogicals_with_detectors(string=string,
+                                                  logicals=logicals,
+                                                  clbits=clbits,
+                                                  start_ind=len(detectors),
+                                                  **kwargs
+                                                  )
+
+    for node in log_nodes:
+        nodes.append(node)
+
+    return nodes
+
+def string2rawlogicals_with_detectors(
+    string: str,
+    logicals: List[Dict],
+    clbits: QuantumCircuit.clbits,
+    start_ind: int = 0,
+    **kwargs,
+):
+
+    all_logicals = kwargs.get("all_logicals")
+    logical = kwargs.get("logical")
+    if logical is None:
+        logical = "0"
+
+    output_bits = np.array([int(char) for char in string.replace(" ", "")[::-1]])
+
+    clbit_dict = {
+        (clbit._register.name, clbit._index): clind
+        for clind, clbit in enumerate(clbits)
+    }
+
+    nodes = []
+    for index, logical_op in enumerate(logicals, start=start_ind):
         logical_out = 0
         for q in logical_op["clbits"]:
             qind = clbit_dict[q]
@@ -491,13 +548,13 @@ def string2nodes_with_detectors(
                 qubits=[],
                 index=index,
             )
-            # node.properties["basis"] = self.basis
             nodes.append(node)
 
     return nodes
 
-
-def noisify_circuit(circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel):
+def noisify_circuit(
+    circuits: Union[List, QuantumCircuit], noise_model: PauliNoiseModel
+):
     """
     Inserts error operations into a circuit according to a pauli noise model.
     Handles idling errors in the form of custom gates "idle_#" which are assumed to

--- a/src/qiskit_qec/utils/stim_tools.py
+++ b/src/qiskit_qec/utils/stim_tools.py
@@ -16,7 +16,7 @@
 
 """Tools to use functionality from Stim."""
 from typing import Union, List, Dict, Callable
-from math import log
+from math import log as loga
 from stim import Circuit as StimCircuit
 from stim import DetectorErrorModel as StimDetectorErrorModel
 from stim import DemInstruction as StimDemInstruction
@@ -404,7 +404,7 @@ def detector_error_model_to_rx_graph(
             )
             edge = DecodingGraphEdge(
                 qubits=qubits,
-                weight=log((1 - p) / p),
+                weight=loga((1 - p) / p),
                 properties={"fault_ids": set(frame_changes), "error_probability": p},
             )
             g.add_edge(dets[0], dets[1], edge)
@@ -457,10 +457,17 @@ def string2nodes_with_detectors(
     `DecodingGraph`.
     Args:
         string (string): Results string to convert.
-        detectors:
-        logicals:
-        clbits:
-        det_ref_values:
+        detectors: A list of measurement comparisons. A measurement comparison
+                (detector) is either a list of measurements given by a the name and index
+                of the classical bit or a list of dictionaries, with a mandatory clbits
+                key containing the classical bits. A dictionary can contain keys like
+                'qubits', 'time', 'basis' etc.
+        logicals: A list of logical measurements. A logical measurement is a
+                list of classical bits whose total parity is the logical eigenvalue.
+                Again it can be a list of dictionaries.
+        clbits: classical bits of the qiskit circuit, needed to identify
+                measurements in the output string
+        det_ref_values: Reference value for the detector outcomes, 0 by default
 
         kwargs (dict): Any additional keyword arguments.
             logical (str): Logical value whose results are used ('0' as default).

--- a/test/code_circuits/test_css_codes_with_stim.py
+++ b/test/code_circuits/test_css_codes_with_stim.py
@@ -21,6 +21,7 @@ from qiskit_qec.circuits.css_code import CSSCodeCircuit
 from qiskit_qec.decoders.decoding_graph import DecodingGraph
 from qiskit_qec.utils.stim_tools import get_stim_circuits
 
+
 class TestCircuitMatcher(unittest.TestCase):
     """Test for the CSSCodeCircuit class for Heavy-HEX code with pymatching"""
 
@@ -39,7 +40,9 @@ class TestCircuitMatcher(unittest.TestCase):
             graph = DecodingGraph(css_code).graph
             m = pymatching.Matching(graph)
             detectors, logicals = css_code.stim_detectors()
-            stim_circuit = get_stim_circuits(css_code.noisy_circuit["0"], detectors=detectors, logicals=logicals)[0][0]
+            stim_circuit = get_stim_circuits(
+                css_code.noisy_circuit["0"], detectors=detectors, logicals=logicals
+            )[0][0]
             stim_sampler = stim_circuit.compile_detector_sampler()
             num_correct = 0
             stim_samples = stim_sampler.sample(num_shots, append_observables=True)

--- a/test/code_circuits/test_css_codes_with_stim.py
+++ b/test/code_circuits/test_css_codes_with_stim.py
@@ -17,7 +17,7 @@ import unittest
 import pymatching
 
 from qiskit_qec.codes.hhc import HHC
-from qiskit_qec.circuits.css_code import CSSCodeCircuit, stim_detectors
+from qiskit_qec.circuits.css_code import CSSCodeCircuit
 from qiskit_qec.decoders.decoding_graph import DecodingGraph
 from qiskit_qec.utils.stim_tools import get_stim_circuits
 
@@ -38,7 +38,7 @@ class TestCircuitMatcher(unittest.TestCase):
             css_code = CSSCodeCircuit(code, T=d, basis="x", noise_model=(error_rate, error_rate))
             graph = DecodingGraph(css_code).graph
             m = pymatching.Matching(graph)
-            detectors, logicals = stim_detectors()
+            detectors, logicals = css_code.stim_detectors()
             stim_circuit = get_stim_circuits(css_code.noisy_circuit["0"], detectors=detectors, logicals=logicals)[0][0]
             stim_sampler = stim_circuit.compile_detector_sampler()
             num_correct = 0

--- a/test/code_circuits/test_css_codes_with_stim.py
+++ b/test/code_circuits/test_css_codes_with_stim.py
@@ -17,9 +17,9 @@ import unittest
 import pymatching
 
 from qiskit_qec.codes.hhc import HHC
-from qiskit_qec.circuits.css_code import CSSCodeCircuit
+from qiskit_qec.circuits.css_code import CSSCodeCircuit, stim_detectors
 from qiskit_qec.decoders.decoding_graph import DecodingGraph
-
+from qiskit_qec.utils.stim_tools import get_stim_circuits
 
 class TestCircuitMatcher(unittest.TestCase):
     """Test for the CSSCodeCircuit class for Heavy-HEX code with pymatching"""
@@ -38,7 +38,8 @@ class TestCircuitMatcher(unittest.TestCase):
             css_code = CSSCodeCircuit(code, T=d, basis="x", noise_model=(error_rate, error_rate))
             graph = DecodingGraph(css_code).graph
             m = pymatching.Matching(graph)
-            stim_circuit = css_code.stim_circuit_with_detectors()["0"]
+            detectors, logicals = stim_detectors()
+            stim_circuit = get_stim_circuits(css_code.noisy_circuit["0"], detectors=detectors, logicals=logicals)[0][0]
             stim_sampler = stim_circuit.compile_detector_sampler()
             num_correct = 0
             stim_samples = stim_sampler.sample(num_shots, append_observables=True)

--- a/test/code_circuits/test_rep_codes.py
+++ b/test/code_circuits/test_rep_codes.py
@@ -538,7 +538,7 @@ class TestDecoding(unittest.TestCase):
         # now run them all and check it works
         for c, code in enumerate(codes):
             decoding_graph = DecodingGraph(code)
-            if c == 3 and Decoder is UnionFindDecoder:
+            if c >= 0 and Decoder is UnionFindDecoder:
                 decoder = Decoder(code, decoding_graph=decoding_graph, use_peeling=False)
             else:
                 decoder = Decoder(code, decoding_graph=decoding_graph)
@@ -555,7 +555,7 @@ class TestDecoding(unittest.TestCase):
                 for j, z_logical in enumerate(decoder.measured_logicals):
                     error = corrected_z_logicals[j] != 1
                     if error:
-                        error_num = string.count("0")
+                        error_num = string.split(" ", maxsplit=1)[0].count("0")
                         if error_num < min_error_num:
                             min_error_num = error_num
                             min_error_string = string


### PR DESCRIPTION
Adding a StimCodeCircuit class to convert stim circuits into qiskit circuits with the useful features expected from a qiskit-qec CodeCircuit.

This PR also includes a couple of updates to the previous 339-integrate-stim PR, like creating an abstract detector information in both the CSS and the Stim CodeCircuit classes which is then used by the stim circuits as well as the string2nodes methods

See detailed comments under the commits.
