### PR TITLE
Depend on qiskit directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit~=0.43
+qiskit>=0.43,<1
 qiskit-aer>=0.11.0
 qiskit_ibm_provider>=0.5.0
 pybind11<=2.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit-terra>=0.24.0
+qiskit~=0.43
 qiskit-aer>=0.11.0
 qiskit_ibm_provider>=0.5.0
 pybind11<=2.9.1


### PR DESCRIPTION
### Summary

Currently, `qiskit-qec` depends on `qiskit-terra`. Starting in Qiskit 1.0.0 only the `qiskit` package will be published. This PR changes the requirement to use `qiskit` instead of `qiskit-terra`. In this case, it stays in 0.* with `<1` 

### Details and comments

https://github.com/Qiskit/qiskit/pull/11230