### PR TITLE
add missing include statement in distance.h

### DIFF
--- a/src/qiskit_qec/analysis/distance.h
+++ b/src/qiskit_qec/analysis/distance.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <set>
 #include <exception>
+#include <iterator>
 
 #include "linear.h"
 #include "combinations.h"

--- a/src/qiskit_qec/analysis/distance.py
+++ b/src/qiskit_qec/analysis/distance.py
@@ -113,14 +113,12 @@ def _minimum_distance_2_python(stabilizer: np.ndarray, gauge: np.ndarray, max_we
     for row in range(xl.shape[0]):
         for w in range(1, max_weight + 1):
             if _distance_test(stabilizer.astype(int), xl[row].astype(int), w):
-                if w < weight:
-                    weight = w
+                weight = min(weight, w)
                 break
     for row in range(zl.shape[0]):
         for w in range(1, max_weight + 1):
             if _distance_test(stabilizer.astype(int), zl[row].astype(int), w):
-                if w < weight:
-                    weight = w
+                weight = min(weight, w)
                 break
     if weight < max_weight + 1:
         return weight

--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -322,7 +322,7 @@ class DecodingGraph:
 
         boundary_nodes = []
         for n, node in enumerate(self.graph.nodes()):
-            if node.is_boundary:
+            if node.is_logical:
                 boundary_nodes.append(n)
 
         for edge in self.graph.edge_list():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ x] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary
fixes #422.
Adds a missing include statement in one of the C++ header files such that the C++ compiler does not exit with a fatal error.


### Details and comments
The issue seems to only appear when installing the project on Windows. This can be due to different C++ compilers used by different operating systems (Clang on macOS and MSVC on Windows). It is possible that Clang is more permissive with missing include statements of the standard library, while MSVC is more strict. However, adding the include statement explicitly will not affect the behavior on macOS machines.
