### PR TITLE
Weighting decoding graphs

### DIFF
--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -326,7 +326,7 @@ class DecodingGraph:
         elif error_probs!={}:
             error_probs = error_probs
         else:
-            raise NotImplementedError("No information provided to reweight the graph. "+
+            raise NotImplementedError("No information provided to reweight the graph."+
                                       "Specify either counts or error_probs.")
 
         boundary_nodes = []

--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -331,7 +331,7 @@ class DecodingGraph:
 
         boundary_nodes = []
         for n, node in enumerate(self.graph.nodes()):
-            if node.is_boundary:
+            if node.is_logical:
                 boundary_nodes.append(n)
 
         for edge in self.graph.edge_list():

--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -303,7 +303,8 @@ class DecodingGraph:
         else:
             return error_probs
 
-    def weight_syndrome_graph(self, counts, method: str = METHOD_SPITZ):
+    def weight_syndrome_graph(self, counts: dict = {}, method: str = METHOD_SPITZ,
+                              error_probs: dict = {}):
         """Generate weighted syndrome graph from result counts.
 
         Args:
@@ -311,6 +312,8 @@ class DecodingGraph:
             the weights.
             method (string): Method to used for calculation. Supported
             methods are 'spitz' (default) and 'naive'.
+            error_probs (dict): probability that the syndrome contains the node pair
+            of a given edge. Overridden by counts if both are given. 
 
         Additional information:
             Uses `counts` to estimate the probability of the errors that
@@ -318,11 +321,17 @@ class DecodingGraph:
             replaced with the corresponding -log(p/(1-p).
         """
 
-        error_probs = self.get_error_probs(counts, method=method)
+        if counts!={}:
+            error_probs = self.get_error_probs(counts, method=method)
+        elif error_probs!={}:
+            error_probs = error_probs
+        else:
+            raise NotImplementedError("No information provided to reweight the graph. "+
+                                      "Specify either counts or error_probs.")
 
         boundary_nodes = []
         for n, node in enumerate(self.graph.nodes()):
-            if node.is_logical:
+            if node.is_boundary:
                 boundary_nodes.append(n)
 
         for edge in self.graph.edge_list():

--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -304,7 +304,7 @@ class DecodingGraph:
             return error_probs
 
     def weight_syndrome_graph(
-        self, counts: dict = {}, method: str = METHOD_SPITZ, error_probs: dict = {}
+        self, counts: dict = None, method: str = METHOD_SPITZ, error_probs: dict = None
     ):
         """Generate weighted syndrome graph from result counts.
 
@@ -322,11 +322,9 @@ class DecodingGraph:
             replaced with the corresponding -log(p/(1-p).
         """
 
-        if counts != {}:
+        if counts != None:
             error_probs = self.get_error_probs(counts, method=method)
-        elif error_probs != {}:
-            error_probs = error_probs
-        else:
+        elif error_probs == None:
             raise NotImplementedError(
                 "No information provided to reweight the graph."
                 + "Specify either counts or error_probs."

--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -322,9 +322,9 @@ class DecodingGraph:
             replaced with the corresponding -log(p/(1-p).
         """
 
-        if counts != None:
+        if counts:
             error_probs = self.get_error_probs(counts, method=method)
-        elif error_probs == None:
+        elif not error_probs:
             raise NotImplementedError(
                 "No information provided to reweight the graph."
                 + "Specify either counts or error_probs."

--- a/src/qiskit_qec/decoders/decoding_graph.py
+++ b/src/qiskit_qec/decoders/decoding_graph.py
@@ -303,8 +303,9 @@ class DecodingGraph:
         else:
             return error_probs
 
-    def weight_syndrome_graph(self, counts: dict = {}, method: str = METHOD_SPITZ,
-                              error_probs: dict = {}):
+    def weight_syndrome_graph(
+        self, counts: dict = {}, method: str = METHOD_SPITZ, error_probs: dict = {}
+    ):
         """Generate weighted syndrome graph from result counts.
 
         Args:
@@ -313,7 +314,7 @@ class DecodingGraph:
             method (string): Method to used for calculation. Supported
             methods are 'spitz' (default) and 'naive'.
             error_probs (dict): probability that the syndrome contains the node pair
-            of a given edge. Overridden by counts if both are given. 
+            of a given edge. Overridden by counts if both are given.
 
         Additional information:
             Uses `counts` to estimate the probability of the errors that
@@ -321,13 +322,15 @@ class DecodingGraph:
             replaced with the corresponding -log(p/(1-p).
         """
 
-        if counts!={}:
+        if counts != {}:
             error_probs = self.get_error_probs(counts, method=method)
-        elif error_probs!={}:
+        elif error_probs != {}:
             error_probs = error_probs
         else:
-            raise NotImplementedError("No information provided to reweight the graph."+
-                                      "Specify either counts or error_probs.")
+            raise NotImplementedError(
+                "No information provided to reweight the graph."
+                + "Specify either counts or error_probs."
+            )
 
         boundary_nodes = []
         for n, node in enumerate(self.graph.nodes()):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Allowing the user to provide costume weights for DecodingGraph.weight_syndrome_graph() as a new argument "error_probs".

### Details and comments

- "counts" is not a required argument anymore
- "error_probs" is also not required and overridden by counts if both of them are provided
- at least one of the above arguments should be specified to avoid NotImplementedError

