### PR TITLE
Update CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# Check for updates to GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.8, 3.11]
-        os: ["ubuntu-latest", "macOS-13", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,54 +5,71 @@ on:
     branches:
       - main
       - 'stable/**'
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    if: github.repository_owner == 'qiskit-community'
+    name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.8, 3.11]
+        os: ["ubuntu-latest", "macOS-13", "windows-latest"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Pip cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements.txt','requirements-dev.txt') }}
     - name: Set up tox env
       run: |
-        python -m pip install --upgrade pip
-        pip install tox 
-        pver=${{ matrix.python-version }}
-        tox_env="-epy${pver/./}"
-        echo tox_env
-        echo TOX_ENV=$tox_env >> $GITHUB_ENV
+        python -m pip install -U tox 
     - name: Test using tox envs
       run: |
-        tox -vv ${{ env.TOX_ENV }}
+        tox -vv -e py
   lint:
+    if: github.repository_owner == 'qiskit-community'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
           python-version: '3.9'
+    - name: Pip cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-lint-${{ hashFiles('setup.py','requirements.txt','requirements-dev.txt') }}
     - name: Install tox
       run: |
-        python -m pip install --upgrade pip
-        pip install tox
+        python -m pip install -U tox
     - name: Run styles check
       run: tox -elint
   docs:
+    if: github.repository_owner == 'qiskit-community'
     name: Docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
           python-version: '3.9'
+    - name: Pip cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-docs-${{ hashFiles('setup.py','requirements.txt','requirements-dev.txt') }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
- Update old GitHub Actions and add dependabot for automatic Github Actions updates
- Add concurrency check to stop old CI jobs if there are new pushes to the PR
- Add macos and windows tests
- Add caching during tests
- Prevent CI from running automatically on forks